### PR TITLE
docs(README): Update Capacitor version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 Capacitor ML Kit is a collection of Capacitor plugins that enable the use of the [ML Kit SDKs](https://developers.google.com/ml-kit) in Capacitor.[^1]
 
 - 🔋 Supports **Android and iOS**
-- ⚡️ **Capacitor 4** support
+- ⚡️ **Capacitor 5** support
 - 🦋 Consistent versioning (no more SDK versions conflicts)
 - 👁 Unified Typescript definitions
 - 📄 Full documentation


### PR DESCRIPTION
The BREAKING.md files say that version 5 of the plugin is for Capacitor 5, so the README should also say Capacitor 5