### PR TITLE
feat(barcode-scanning): support `cornerPoints` in `readBarcodesFromImage(...)`

### DIFF
--- a/packages/barcode-scanning/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/barcodescanning/BarcodeScannerHelper.java
+++ b/packages/barcode-scanning/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/barcodescanning/BarcodeScannerHelper.java
@@ -30,7 +30,14 @@ public class BarcodeScannerHelper {
                 cornerPointsResult.put(cornerPointResult);
             }
         }
-
+        else if (cornerPoints != null) {
+            for (int i = 0; i < cornerPoints.length; i++) {
+                JSArray cornerPointResult = new JSArray();
+                cornerPointResult.put(cornerPoints[i].x);
+                cornerPointResult.put(cornerPoints[i].y);
+                cornerPointsResult.put(cornerPointResult);
+            }
+        }
         JSObject result = new JSObject();
         result.put("bytes", convertByteArrayToJsonArray(barcode.getRawBytes()));
         if (cornerPoints != null) {

--- a/packages/barcode-scanning/ios/Plugin/BarcodeScanner.swift
+++ b/packages/barcode-scanning/ios/Plugin/BarcodeScanner.swift
@@ -68,6 +68,7 @@ typealias MLKitBarcodeScanner = MLKitBarcodeScanning.BarcodeScanner
             }
             CAPLog.print("\(features?.count ?? 0)")
             guard let features = features, !features.isEmpty else {
+                completion(features, nil)
                 return
             }
             completion(features, nil)

--- a/packages/barcode-scanning/ios/Plugin/BarcodeScannerHelper.swift
+++ b/packages/barcode-scanning/ios/Plugin/BarcodeScannerHelper.swift
@@ -39,7 +39,14 @@ public class BarcodeScannerHelper {
                 cornerPointsResult.append(value)
             }
         }
-
+        else if let cornerPoints = barcode.cornerPoints {
+            for cornerPoint in cornerPoints {
+                var value = [Int]()
+                value.append(Int(cornerPoint.cgPointValue.x))
+                value.append(Int(cornerPoint.cgPointValue.y))
+                cornerPointsResult.append(value)
+            }
+        }
         var result = JSObject()
         if let rawData = barcode.rawData {
             result["bytes"] = convertDataToJsonArray(rawData)

--- a/packages/barcode-scanning/package.json
+++ b/packages/barcode-scanning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor-mlkit/barcode-scanning",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Capacitor plugin for ML Kit Barcode Scanning.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [ ] A changeset has been created (`npm run changeset`).


This improved two things :
- Includes raw cornerPoints in the result data of "readBarcodesFromImage" and "scan" on iOS instead of empty array.
- Returns empty data when there is no detection on readBarcodesFromImage instead of having a call hanging.

Close #39 and for my personal usage
