### PR TITLE
fix: update AVCaptureSession.Preset resolution, enable ultrawide camera

### DIFF
--- a/packages/barcode-scanning/ios/Plugin/BarcodeScannerView.swift
+++ b/packages/barcode-scanning/ios/Plugin/BarcodeScannerView.swift
@@ -43,7 +43,7 @@ public protocol BarcodeScannerViewDelegate {
 
         let captureSession = AVCaptureSession()
         captureSession.beginConfiguration()
-        captureSession.sessionPreset = AVCaptureSession.Preset.hd1280x720
+        captureSession.sessionPreset = AVCaptureSession.Preset.hd1920x1080
 
         // Prepare capture session and preview layer
         // It executes tasks one at a time in the order they are added (FIFO), ensuring that no other
@@ -51,7 +51,17 @@ public protocol BarcodeScannerViewDelegate {
         // block
         captureSessionQueue.sync {
             do {
-                let captureDevice = AVCaptureDevice.default(.builtInWideAngleCamera, for: AVMediaType.video, position: settings.lensFacing)
+                let captureDevice: AVCaptureDevice? = {
+                  if let device = AVCaptureDevice.default(.builtInTripleCamera, for: .video, position: settings.lensFacing) {
+                      return device
+                  } else if let device = AVCaptureDevice.default(.builtInDualCamera, for: .video, position: settings.lensFacing) {
+                      return device
+                  } else {
+                    let device = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: settings.lensFacing)
+                      return device
+                  }
+                }()
+
                 guard let captureDevice = captureDevice else {
                     throw RuntimeError(implementation.plugin.errorNoCaptureDeviceAvailable)
                 }


### PR DESCRIPTION
iPhone devices after iPhone 13 have macro mode of capturing, in order for device to use it ultraWideAngle camera must be enabled. This commit enables ultraWide(tripleCamera) if the device supports it, if not it enables dualCamera, if none of them is available then it uses wideCamera that every iPhone has.

also this commit changes AVCaptureSession.Preset resolution to hd1920x1080, since it is not anymore problem for the device to analyze frames of that size. It improves oveerall scanning, scanning is much faster.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The changes have been tested successfully.
- [ ] A changeset has been created (`npm run changeset`).
- [ ] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

