### PR TITLE
fix #254: configure capture device before starting capture session

### DIFF
--- a/.changeset/shy-humans-camp.md
+++ b/.changeset/shy-humans-camp.md
@@ -2,4 +2,4 @@
 '@capacitor-mlkit/barcode-scanning': patch
 ---
 
-barcode-scanning: Resolve intermittent issue with preview display on iOS
+fix(barcode-scanning): opening and closing repeatedly occasionally results in a black screen

--- a/.changeset/shy-humans-camp.md
+++ b/.changeset/shy-humans-camp.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-mlkit/barcode-scanning': patch
+---
+
+barcode-scanning: Resolve intermittent issue with preview display on iOS

--- a/packages/barcode-scanning/ios/Plugin/BarcodeScannerView.swift
+++ b/packages/barcode-scanning/ios/Plugin/BarcodeScannerView.swift
@@ -83,6 +83,9 @@ public protocol BarcodeScannerViewDelegate {
                 } else {
                     throw RuntimeError(implementation.plugin.errorCannotAddCaptureOutput)
                 }
+                // Configure capture device to set the correct focus mode and exposure mode.
+                // This must be called before commiting the configuration to the capture session
+                // and after adding the device input to the capture session.
                 self.configureCaptureDevice(captureDevice)
 
                 captureSession.commitConfiguration()

--- a/packages/barcode-scanning/ios/Plugin/BarcodeScannerView.swift
+++ b/packages/barcode-scanning/ios/Plugin/BarcodeScannerView.swift
@@ -83,6 +83,7 @@ public protocol BarcodeScannerViewDelegate {
                 } else {
                     throw RuntimeError(implementation.plugin.errorCannotAddCaptureOutput)
                 }
+                self.configureCaptureDevice(captureDevice)
 
                 captureSession.commitConfiguration()
                 self.captureSession = captureSession
@@ -105,7 +106,6 @@ public protocol BarcodeScannerViewDelegate {
         DispatchQueue.main.async {
             guard let captureDevice = self.captureDevice else { return }
             guard let captureSession = self.captureSession else { return }
-            self.configureCaptureDevice(captureDevice)
             let formats = self.settings.formats.isEmpty ? BarcodeFormat.all : BarcodeFormat(self.settings.formats)
             self.barcodeScannerInstance = MLKitBarcodeScanner.barcodeScanner(options: BarcodeScannerOptions(formats: formats))
             self.setVideoPreviewLayer(AVCaptureVideoPreviewLayer(session: captureSession))


### PR DESCRIPTION
This resolves an intermittent issue with the preview screen displaying as black.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).


Close #254