### PR TITLE
fix: AVCaptureSession race condition crash

### DIFF
--- a/.changeset/tough-elephants-sparkle.md
+++ b/.changeset/tough-elephants-sparkle.md
@@ -1,5 +1,5 @@
 ---
-'@capacitor-mlkit/barcode-scanning': minor
+'@capacitor-mlkit/barcode-scanning': patch
 ---
 
-fix: moved video preview layer setup outside of async task to prevent race condition related crash on AVCaprtureSession.startRunning()
+fix(ios): prevent crash due to a race condition at the start of the scan

--- a/.changeset/tough-elephants-sparkle.md
+++ b/.changeset/tough-elephants-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-mlkit/barcode-scanning': minor
+---
+
+fix: moved video preview layer setup outside of async task to prevent race condition related crash on AVCaprtureSession.startRunning()

--- a/packages/barcode-scanning/ios/Plugin/BarcodeScannerView.swift
+++ b/packages/barcode-scanning/ios/Plugin/BarcodeScannerView.swift
@@ -99,6 +99,8 @@ public protocol BarcodeScannerViewDelegate {
         if let error = setupError {
             throw error
         }
+        
+        self.setVideoPreviewLayer(AVCaptureVideoPreviewLayer(session: captureSession))
 
         // Add Start task to the queue in the order, each task starts only after the previous task has
         // finished, ensuring captureSession.startRunning() starts after the sync block
@@ -111,7 +113,6 @@ public protocol BarcodeScannerViewDelegate {
             guard let captureSession = self.captureSession else { return }
             let formats = self.settings.formats.isEmpty ? BarcodeFormat.all : BarcodeFormat(self.settings.formats)
             self.barcodeScannerInstance = MLKitBarcodeScanner.barcodeScanner(options: BarcodeScannerOptions(formats: formats))
-            self.setVideoPreviewLayer(AVCaptureVideoPreviewLayer(session: captureSession))
 
             if self.settings.showUIElements {
                 self.addCancelButton()

--- a/packages/barcode-scanning/ios/Plugin/BarcodeScannerView.swift
+++ b/packages/barcode-scanning/ios/Plugin/BarcodeScannerView.swift
@@ -105,6 +105,8 @@ public protocol BarcodeScannerViewDelegate {
         // See https://github.com/capawesome-team/capacitor-mlkit/issues/258 for details
         self.setVideoPreviewLayer(AVCaptureVideoPreviewLayer(session: captureSession))
 
+        // Add Start task to the queue in the order, each task starts only after the previous task has
+        // finished, ensuring captureSession.startRunning() starts after the sync block
         captureSessionQueue.async {
             captureSession.startRunning()
         }

--- a/packages/barcode-scanning/ios/Plugin/BarcodeScannerView.swift
+++ b/packages/barcode-scanning/ios/Plugin/BarcodeScannerView.swift
@@ -100,10 +100,11 @@ public protocol BarcodeScannerViewDelegate {
             throw error
         }
         
+        // Moved videoPreview setup outside async task in main dispatch queue.
+        // This prevents inconsistent behavior when calling startScan() multiple times quickly.
+        // See https://github.com/capawesome-team/capacitor-mlkit/issues/258 for details
         self.setVideoPreviewLayer(AVCaptureVideoPreviewLayer(session: captureSession))
 
-        // Add Start task to the queue in the order, each task starts only after the previous task has
-        // finished, ensuring captureSession.startRunning() starts after the sync block
         captureSessionQueue.async {
             captureSession.startRunning()
         }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

Addresses race condition related crash when AVCaptureSession.startRunning is called while the session is being configured and has not been committed. Hypothesis is that setting either the `AVCaptureCideoPreviewLayer`'s frame or videoGravity was causing some internal configuration change for the CaptureSession. Because this was being done in an async block in the main dispatch queue, this was causing inconsistent behaviour when calling startScan() multiple times quickly. Moved the videoPreview setup outside of an async task in the main dispatch queue which has fixed the issue in my testing.

Close [https://github.com/capawesome-team/capacitor-mlkit/issues/258](258).