### PR TITLE
fix(barcode-scanning): `isTorchAvailable` always returning false on iOS

### DIFF
--- a/packages/barcode-scanning/ios/Plugin/BarcodeScanner.swift
+++ b/packages/barcode-scanning/ios/Plugin/BarcodeScanner.swift
@@ -141,10 +141,11 @@ typealias MLKitBarcodeScanner = MLKitBarcodeScanning.BarcodeScanner
     }
 
     @objc public func isTorchAvailable() -> Bool {
-        guard let device = cameraView?.getCaptureDevice() else {
-            return false
+        if let device = cameraView?.getCaptureDevice() {
+            return device.hasTorch
         }
-        return device.hasTorch
+        let device = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .back)
+        return device?.hasTorch ?? false
     }
 
     @objc public func setZoomRatio(_ options: SetZoomRatioOptions) throws {


### PR DESCRIPTION
  ## Pull request checklist

  Please check if your PR fulfills the following requirements:

  - [x] The changes have been tested successfully.
  - [ ] A changeset has been created (`npm run changeset`).
  - [x] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

  ## Summary

  - On iOS, `isTorchAvailable()` always returned `false` when called outside an active scan session because it relied on `cameraView?.getCaptureDevice()`, which is `nil` when no scan is running.
  - Added a fallback to query the default wide-angle camera device directly when no scan session is active, matching Android's behavior of checking hardware capabilities independently of camera session state.

  Fixes #293