### PR TITLE
chore: fix swiftlint scanning dependency files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       ],
       "devDependencies": {
         "@changesets/cli": "2.29.8",
+        "@ionic/swiftlint-config": "2.0.0",
         "@robingenz/changelog-github": "0.0.1",
         "patch-package": "8.0.1",
         "pkg-pr-new": "0.0.20",
@@ -7474,7 +7475,7 @@
     },
     "packages/barcode-scanning": {
       "name": "@capacitor-mlkit/barcode-scanning",
-      "version": "7.0.0",
+      "version": "8.0.1",
       "funding": [
         {
           "type": "github",
@@ -7493,7 +7494,6 @@
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
-        "@ionic/swiftlint-config": "2.0.0",
         "eslint": "8.57.0",
         "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
@@ -7524,7 +7524,7 @@
     },
     "packages/document-scanner": {
       "name": "@capacitor-mlkit/document-scanner",
-      "version": "7.0.0",
+      "version": "8.0.1",
       "funding": [
         {
           "type": "github",
@@ -7543,7 +7543,6 @@
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
-        "@ionic/swiftlint-config": "2.0.0",
         "eslint": "8.57.0",
         "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
@@ -7574,7 +7573,7 @@
     },
     "packages/face-detection": {
       "name": "@capacitor-mlkit/face-detection",
-      "version": "7.0.0",
+      "version": "8.0.1",
       "funding": [
         {
           "type": "github",
@@ -7593,7 +7592,6 @@
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
-        "@ionic/swiftlint-config": "2.0.0",
         "eslint": "8.57.0",
         "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
@@ -7624,7 +7622,7 @@
     },
     "packages/face-mesh-detection": {
       "name": "@capacitor-mlkit/face-mesh-detection",
-      "version": "7.0.0",
+      "version": "8.0.1",
       "funding": [
         {
           "type": "github",
@@ -7643,7 +7641,6 @@
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
-        "@ionic/swiftlint-config": "2.0.0",
         "eslint": "8.57.0",
         "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
@@ -7674,7 +7671,7 @@
     },
     "packages/selfie-segmentation": {
       "name": "@capacitor-mlkit/selfie-segmentation",
-      "version": "7.0.0",
+      "version": "8.0.1",
       "funding": [
         {
           "type": "github",
@@ -7693,7 +7690,6 @@
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
-        "@ionic/swiftlint-config": "2.0.0",
         "eslint": "8.57.0",
         "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
@@ -7724,7 +7720,7 @@
     },
     "packages/subject-segmentation": {
       "name": "@capacitor-mlkit/subject-segmentation",
-      "version": "7.0.0",
+      "version": "8.0.1",
       "funding": [
         {
           "type": "github",
@@ -7743,7 +7739,6 @@
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
-        "@ionic/swiftlint-config": "2.0.0",
         "eslint": "8.57.0",
         "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
@@ -7774,7 +7769,7 @@
     },
     "packages/translation": {
       "name": "@capacitor-mlkit/translation",
-      "version": "7.0.0",
+      "version": "8.0.1",
       "funding": [
         {
           "type": "github",
@@ -7793,7 +7788,6 @@
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
-        "@ionic/swiftlint-config": "2.0.0",
         "eslint": "8.57.0",
         "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@changesets/cli": "2.29.8",
+    "@ionic/swiftlint-config": "2.0.0",
     "@robingenz/changelog-github": "0.0.1",
     "patch-package": "8.0.1",
     "pkg-pr-new": "0.0.20",

--- a/packages/barcode-scanning/.swiftlintrc.js
+++ b/packages/barcode-scanning/.swiftlintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('../../swiftlint.config.js');

--- a/packages/barcode-scanning/package.json
+++ b/packages/barcode-scanning/package.json
@@ -62,7 +62,6 @@
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
-    "@ionic/swiftlint-config": "2.0.0",
     "eslint": "8.57.0",
     "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
@@ -74,7 +73,6 @@
   "peerDependencies": {
     "@capacitor/core": ">=8.0.0"
   },
-  "swiftlint": "@ionic/swiftlint-config",
   "eslintConfig": {
     "extends": "@ionic/eslint-config/recommended"
   },

--- a/packages/document-scanner/.swiftlintrc.js
+++ b/packages/document-scanner/.swiftlintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('../../swiftlint.config.js');

--- a/packages/document-scanner/package.json
+++ b/packages/document-scanner/package.json
@@ -62,7 +62,6 @@
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
-    "@ionic/swiftlint-config": "2.0.0",
     "eslint": "8.57.0",
     "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
@@ -74,7 +73,6 @@
   "peerDependencies": {
     "@capacitor/core": ">=8.0.0"
   },
-  "swiftlint": "@ionic/swiftlint-config",
   "eslintConfig": {
     "extends": "@ionic/eslint-config/recommended"
   },

--- a/packages/face-detection/.swiftlintrc.js
+++ b/packages/face-detection/.swiftlintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('../../swiftlint.config.js');

--- a/packages/face-detection/package.json
+++ b/packages/face-detection/package.json
@@ -62,7 +62,6 @@
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
-    "@ionic/swiftlint-config": "2.0.0",
     "eslint": "8.57.0",
     "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
@@ -74,7 +73,6 @@
   "peerDependencies": {
     "@capacitor/core": ">=8.0.0"
   },
-  "swiftlint": "@ionic/swiftlint-config",
   "eslintConfig": {
     "extends": "@ionic/eslint-config/recommended"
   },

--- a/packages/face-mesh-detection/.swiftlintrc.js
+++ b/packages/face-mesh-detection/.swiftlintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('../../swiftlint.config.js');

--- a/packages/face-mesh-detection/package.json
+++ b/packages/face-mesh-detection/package.json
@@ -62,7 +62,6 @@
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
-    "@ionic/swiftlint-config": "2.0.0",
     "eslint": "8.57.0",
     "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
@@ -74,7 +73,6 @@
   "peerDependencies": {
     "@capacitor/core": ">=8.0.0"
   },
-  "swiftlint": "@ionic/swiftlint-config",
   "eslintConfig": {
     "extends": "@ionic/eslint-config/recommended"
   },

--- a/packages/selfie-segmentation/.swiftlintrc.js
+++ b/packages/selfie-segmentation/.swiftlintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('../../swiftlint.config.js');

--- a/packages/selfie-segmentation/package.json
+++ b/packages/selfie-segmentation/package.json
@@ -62,7 +62,6 @@
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
-    "@ionic/swiftlint-config": "2.0.0",
     "eslint": "8.57.0",
     "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
@@ -74,7 +73,6 @@
   "peerDependencies": {
     "@capacitor/core": ">=8.0.0"
   },
-  "swiftlint": "@ionic/swiftlint-config",
   "eslintConfig": {
     "extends": "@ionic/eslint-config/recommended"
   },

--- a/packages/subject-segmentation/.swiftlintrc.js
+++ b/packages/subject-segmentation/.swiftlintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('../../swiftlint.config.js');

--- a/packages/subject-segmentation/package.json
+++ b/packages/subject-segmentation/package.json
@@ -62,7 +62,6 @@
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
-    "@ionic/swiftlint-config": "2.0.0",
     "eslint": "8.57.0",
     "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
@@ -74,7 +73,6 @@
   "peerDependencies": {
     "@capacitor/core": ">=8.0.0"
   },
-  "swiftlint": "@ionic/swiftlint-config",
   "eslintConfig": {
     "extends": "@ionic/eslint-config/recommended"
   },

--- a/packages/translation/.swiftlintrc.js
+++ b/packages/translation/.swiftlintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('../../swiftlint.config.js');

--- a/packages/translation/package.json
+++ b/packages/translation/package.json
@@ -62,7 +62,6 @@
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
-    "@ionic/swiftlint-config": "2.0.0",
     "eslint": "8.57.0",
     "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
@@ -74,7 +73,6 @@
   "peerDependencies": {
     "@capacitor/core": ">=8.0.0"
   },
-  "swiftlint": "@ionic/swiftlint-config",
   "eslintConfig": {
     "extends": "@ionic/eslint-config/recommended"
   },

--- a/swiftlint.config.js
+++ b/swiftlint.config.js
@@ -1,0 +1,10 @@
+const base = require('@ionic/swiftlint-config');
+
+module.exports = {
+  ...base,
+  excluded: [
+    ...(base.excluded || []).map((p) => p.replace('${PWD}', process.cwd())),
+    `${process.cwd()}/.build`,
+    `${process.cwd()}/example`,
+  ],
+};


### PR DESCRIPTION
`node-swiftlint` writes the `@ionic/swiftlint-config` as JSON to a temp file, but SwiftLint only expands `${PWD}` in YAML configs. This means the exclusion rules were silently broken — swiftlint was scanning all dependency files (`.build/`, `ios/Pods/`, `example/`).

Changes:
- Add root `swiftlint.config.js` that resolves `${PWD}` at JS evaluation time
- Add per-package `.swiftlintrc.js` that delegates to the shared root config
- Move `@ionic/swiftlint-config` from per-package to root devDependencies