### PR TITLE
fix(barcode-scanning): add missing listenablefuture dependency

### DIFF
--- a/.changeset/fix-barcode-scanning-listenablefuture.md
+++ b/.changeset/fix-barcode-scanning-listenablefuture.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-mlkit/barcode-scanning': patch
+---
+
+fix(barcode-scanning): add missing `listenablefuture` dependency

--- a/packages/barcode-scanning/README.md
+++ b/packages/barcode-scanning/README.md
@@ -95,6 +95,7 @@ If needed, you can define the following project variable in your app’s `variab
 - `$androidxCameraCoreVersion` version of `androidx.camera:camera-core` (default: `1.5.2`)
 - `$androidxCameraLifecycleVersion` version of `androidx.camera:camera-lifecycle` (default: `1.5.2`)
 - `$androidxCameraViewVersion` version of `androidx.camera:camera-view` (default: `1.5.2`)
+- `$listenableFutureVersion` version of `com.google.guava:listenablefuture` (default: `1.0`)
 - `$mlkitBarcodeScanningVersion` version of `com.google.mlkit:barcode-scanning` (default: `17.3.0`)
 - `$playServicesCodeScannerVersion` version of `com.google.android.gms:play-services-code-scanner` (default: `16.1.0`)
 

--- a/packages/barcode-scanning/android/build.gradle
+++ b/packages/barcode-scanning/android/build.gradle
@@ -7,6 +7,7 @@ ext {
     androidxCameraCoreVersion = project.hasProperty('androidxCameraCoreVersion') ? rootProject.ext.androidxCameraCoreVersion : '1.5.2'
     androidxCameraLifecycleVersion = project.hasProperty('androidxCameraLifecycleVersion') ? rootProject.ext.androidxCameraLifecycleVersion : '1.5.2'
     androidxCameraViewVersion = project.hasProperty('androidxCameraViewVersion') ? rootProject.ext.androidxCameraViewVersion : '1.5.2'
+    listenableFutureVersion = project.hasProperty('listenableFutureVersion') ? rootProject.ext.listenableFutureVersion : '1.0'
     mlkitBarcodeScanningVersion = project.hasProperty('mlkitBarcodeScanningVersion') ? rootProject.ext.mlkitBarcodeScanningVersion : '17.3.0'
     playServicesCodeScannerVersion = project.hasProperty('playServicesCodeScannerVersion') ? rootProject.ext.playServicesCodeScannerVersion : '16.1.0'
 }
@@ -62,6 +63,7 @@ dependencies {
     implementation "androidx.camera:camera-core:$androidxCameraCoreVersion"
     implementation "androidx.camera:camera-lifecycle:$androidxCameraLifecycleVersion"
     implementation "androidx.camera:camera-view:$androidxCameraViewVersion"
+    implementation "com.google.guava:listenablefuture:$listenableFutureVersion"
     implementation "com.google.mlkit:barcode-scanning:$mlkitBarcodeScanningVersion"
     implementation "com.google.android.gms:play-services-code-scanner:$playServicesCodeScannerVersion"
     testImplementation "junit:junit:$junitVersion"


### PR DESCRIPTION
## Description

The Android implementation of the `barcode-scanning` plugin imports `com.google.common.util.concurrent.ListenableFuture` but does not declare a Maven dependency for it. It instead relies on a transitive dependency from AndroidX CameraX 1.5.2. CameraX 1.6.0+ no longer exposes Guava transitively, which causes a compilation error when consumers bump the `androidxCamera*Version` variables.

This PR adds an explicit `com.google.guava:listenablefuture` dependency (configurable via `$listenableFutureVersion`, default `1.0`) so the plugin compiles regardless of the CameraX version.

Closes #331