### PR TITLE
docs: update capawesome.io links to new URL structure

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -80,7 +80,7 @@ body:
         A well-written bug report allows the maintainers to quickly recreate the necessary conditions to inspect the bug and quickly find its root cause.
         Please ensure your bug report fulfills all of the following requirements.
       options:
-      - label: I have read and followed the [bug report guidelines](https://capawesome.io/contributing/bug-reports/).
+      - label: I have read and followed the [bug report guidelines](https://capawesome.io/docs/contributing/bug-reports/).
         required: true
       - label: I have attached links to possibly related issues and discussions.
         required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -42,7 +42,7 @@ body:
       description: |
         Please ensure your idea fulfills all of the following requirements.
       options:
-      - label: I have read and followed the [feature request guidelines](https://capawesome.io/contributing/feature-requests/).
+      - label: I have read and followed the [feature request guidelines](https://capawesome.io/docs/contributing/feature-requests/).
         required: true
       - label: I have attached links to possibly related issues and discussions.
         required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,5 +4,5 @@ Please check if your PR fulfills the following requirements:
 
 - [ ] The changes have been tested successfully.
 - [ ] A changeset has been created (`npm run changeset`).
-- [ ] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).
+- [ ] I have read and followed the [pull request guidelines](https://capawesome.io/docs/contributing/pull-requests/).
 

--- a/packages/barcode-scanning/BREAKING.md
+++ b/packages/barcode-scanning/BREAKING.md
@@ -62,7 +62,7 @@ const startScan = async () => {
 
 ### Torch support
 
-All the methods related to the torch have been moved into a separate [Torch](https://capawesome.io/plugins/torch/) plugin. If you want to use the torch, just install the `@capawesome/capacitor-torch` package:
+All the methods related to the torch have been moved into a separate [Torch](https://capawesome.io/docs/sdks/capacitor/torch/) plugin. If you want to use the torch, just install the `@capawesome/capacitor-torch` package:
 
 ```bash
 npm install @capawesome/capacitor-torch

--- a/packages/barcode-scanning/package.json
+++ b/packages/barcode-scanning/package.json
@@ -32,7 +32,7 @@
       "url": "https://opencollective.com/capawesome"
     }
   ],
-  "homepage": "https://capawesome.io/plugins/mlkit/barcode-scanning",
+  "homepage": "https://capawesome.io/docs/sdks/capacitor/mlkit/barcode-scanning",
   "keywords": [
     "capacitor",
     "plugin",

--- a/packages/document-scanner/package.json
+++ b/packages/document-scanner/package.json
@@ -32,7 +32,7 @@
       "url": "https://opencollective.com/capawesome"
     }
   ],
-  "homepage": "https://capawesome.io/plugins/mlkit/document-scanner",
+  "homepage": "https://capawesome.io/docs/sdks/capacitor/mlkit/document-scanner",
   "keywords": [
     "capacitor",
     "plugin",

--- a/packages/face-detection/package.json
+++ b/packages/face-detection/package.json
@@ -32,7 +32,7 @@
       "url": "https://opencollective.com/capawesome"
     }
   ],
-  "homepage": "https://capawesome.io/plugins/mlkit/face-detection/",
+  "homepage": "https://capawesome.io/docs/sdks/capacitor/mlkit/face-detection/",
   "keywords": [
     "capacitor",
     "plugin",

--- a/packages/face-mesh-detection/package.json
+++ b/packages/face-mesh-detection/package.json
@@ -32,7 +32,7 @@
       "url": "https://opencollective.com/capawesome"
     }
   ],
-  "homepage": "https://capawesome.io/plugins/mlkit/face-mesh-detection/",
+  "homepage": "https://capawesome.io/docs/sdks/capacitor/mlkit/face-mesh-detection/",
   "keywords": [
     "capacitor",
     "plugin",

--- a/packages/selfie-segmentation/package.json
+++ b/packages/selfie-segmentation/package.json
@@ -32,7 +32,7 @@
       "url": "https://opencollective.com/capawesome"
     }
   ],
-  "homepage": "https://capawesome.io/plugins/mlkit/selfie-segmentation/",
+  "homepage": "https://capawesome.io/docs/sdks/capacitor/mlkit/selfie-segmentation/",
   "keywords": [
     "capacitor",
     "plugin",

--- a/packages/subject-segmentation/package.json
+++ b/packages/subject-segmentation/package.json
@@ -32,7 +32,7 @@
       "url": "https://opencollective.com/capawesome"
     }
   ],
-  "homepage": "https://capawesome.io/plugins/mlkit/subject-segmentation/",
+  "homepage": "https://capawesome.io/docs/sdks/capacitor/mlkit/subject-segmentation/",
   "keywords": [
     "capacitor",
     "plugin",

--- a/packages/translation/package.json
+++ b/packages/translation/package.json
@@ -32,7 +32,7 @@
       "url": "https://opencollective.com/capawesome"
     }
   ],
-  "homepage": "https://capawesome.io/plugins/mlkit/translation/",
+  "homepage": "https://capawesome.io/docs/sdks/capacitor/mlkit/translation/",
   "keywords": [
     "capacitor",
     "plugin",


### PR DESCRIPTION
## Summary

The capawesome.io documentation moved to a new URL structure. This PR updates all affected links:

- `capawesome.io/plugins/...` → `capawesome.io/docs/sdks/capacitor/...`
- `capawesome.io/contributing/...` → `capawesome.io/docs/contributing/...`

All new URLs were verified to resolve successfully.