### PR TITLE
docs: use human-readable plugin names as README headings

### DIFF
--- a/packages/barcode-scanning/README.md
+++ b/packages/barcode-scanning/README.md
@@ -1,4 +1,4 @@
-# @capacitor-mlkit/barcode-scanning
+# Capacitor ML Kit Barcode Scanning Plugin
 
 Unofficial Capacitor plugin for [ML Kit Barcode Scanning](https://developers.google.com/ml-kit/vision/barcode-scanning).[^1][^2]
 

--- a/packages/document-scanner/README.md
+++ b/packages/document-scanner/README.md
@@ -1,4 +1,4 @@
-# @capacitor-mlkit/document-scanner
+# Capacitor ML Kit Document Scanner Plugin
 
 Unofficial Capacitor plugin for [ML Kit Document Scanner](https://developers.google.com/ml-kit/vision/doc-scanner).[^1]
 

--- a/packages/face-detection/README.md
+++ b/packages/face-detection/README.md
@@ -1,4 +1,4 @@
-# @capacitor-mlkit/face-detection
+# Capacitor ML Kit Face Detection Plugin
 
 Unofficial Capacitor plugin for [ML Kit Face Detection](https://developers.google.com/ml-kit/vision/face-detection).[^1]
 

--- a/packages/face-mesh-detection/README.md
+++ b/packages/face-mesh-detection/README.md
@@ -1,4 +1,4 @@
-# @capacitor-mlkit/face-mesh-detection
+# Capacitor ML Kit Face Mesh Detection Plugin
 
 Unofficial Capacitor plugin for [ML Kit Face Mesh Detection](https://developers.google.com/ml-kit/vision/face-mesh-detection).[^1]
 

--- a/packages/selfie-segmentation/README.md
+++ b/packages/selfie-segmentation/README.md
@@ -1,4 +1,4 @@
-# @capacitor-mlkit/selfie-segmentation
+# Capacitor ML Kit Selfie Segmentation Plugin
 
 Unofficial Capacitor plugin for [ML Kit Selfie Segmentation](https://developers.google.com/ml-kit/vision/selfie-segmentation).[^1]
 

--- a/packages/subject-segmentation/README.md
+++ b/packages/subject-segmentation/README.md
@@ -1,4 +1,4 @@
-# @capacitor-mlkit/subject-segmentation
+# Capacitor ML Kit Subject Segmentation Plugin
 
 Unofficial Capacitor plugin for [ML Kit Subject Segmentation](https://developers.google.com/ml-kit/vision/subject-segmentation).[^1]
 

--- a/packages/translation/README.md
+++ b/packages/translation/README.md
@@ -1,4 +1,4 @@
-# @capacitor-mlkit/translation
+# Capacitor ML Kit Translation Plugin
 
 Unofficial Capacitor plugin for [ML Kit Translation](https://developers.google.com/ml-kit/language/translation).[^1]
 


### PR DESCRIPTION
## Summary

Renames each plugin README's h1 from the npm package name (e.g. `@capacitor-mlkit/translation`) to the human-readable plugin name with a `Plugin` suffix (e.g. "Capacitor ML Kit Translation Plugin").