### PR TITLE
chore: add new plugins to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,10 +10,25 @@ body:
       description: Select the plugins that this bug affects.
       options:
         - label: Barcode Scanning
+        - label: Digital Ink Recognition
+        - label: Document Scanner
+        - label: Entity Extraction
         - label: Face Detection
         - label: Face Mesh Detection
+        - label: GenAI Image Description
+        - label: GenAI Prompt
+        - label: GenAI Proofreading
+        - label: GenAI Rewriting
+        - label: GenAI Speech Recognition
+        - label: GenAI Summarization
+        - label: Image Labeling
+        - label: Language Identification
+        - label: Object Detection
+        - label: Pose Detection
         - label: Selfie Segmentation
+        - label: Smart Reply
         - label: Subject Segmentation
+        - label: Text Recognition
         - label: Translation
   - type: input
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -10,10 +10,25 @@ body:
       description: Select the plugins that this feature request affects.
       options:
         - label: Barcode Scanning
+        - label: Digital Ink Recognition
+        - label: Document Scanner
+        - label: Entity Extraction
         - label: Face Detection
         - label: Face Mesh Detection
+        - label: GenAI Image Description
+        - label: GenAI Prompt
+        - label: GenAI Proofreading
+        - label: GenAI Rewriting
+        - label: GenAI Speech Recognition
+        - label: GenAI Summarization
+        - label: Image Labeling
+        - label: Language Identification
+        - label: Object Detection
+        - label: Pose Detection
         - label: Selfie Segmentation
+        - label: Smart Reply
         - label: Subject Segmentation
+        - label: Text Recognition
         - label: Translation
   - type: textarea
     attributes:


### PR DESCRIPTION
## What

Extends the `Plugin(s)` checkbox list in the bug report and feature request issue templates to cover all 21 plugins — previously only 6 were listed.

Added entries: Digital Ink Recognition, Document Scanner, Entity Extraction, GenAI Image Description, GenAI Prompt, GenAI Proofreading, GenAI Rewriting, GenAI Speech Recognition, GenAI Summarization, Image Labeling, Language Identification, Object Detection, Pose Detection, Smart Reply, Text Recognition.

## Related

- The corresponding `package: <name>` labels were created directly in the repo (`document-scanner` and the six `genai-*` packages), and the `package: subject-detection` label was renamed to `package: subject-segmentation` to match the actual package name.