### PR TITLE
fix(android): use proguard-android-optimize.txt for R8 compatibility

### DIFF
--- a/.changeset/fix-proguard-optimize.md
+++ b/.changeset/fix-proguard-optimize.md
@@ -1,0 +1,13 @@
+---
+"@capacitor-mlkit/digital-ink-recognition": patch
+"@capacitor-mlkit/entity-extraction": patch
+"@capacitor-mlkit/genai-speech-recognition": patch
+"@capacitor-mlkit/image-labeling": patch
+"@capacitor-mlkit/language-identification": patch
+"@capacitor-mlkit/object-detection": patch
+"@capacitor-mlkit/pose-detection": patch
+"@capacitor-mlkit/smart-reply": patch
+"@capacitor-mlkit/text-recognition": patch
+---
+
+fix: use `proguard-android-optimize.txt` for AGP 9.3.0 and R8 compatibility

--- a/packages/digital-ink-recognition/android/build.gradle
+++ b/packages/digital-ink-recognition/android/build.gradle
@@ -31,7 +31,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/digital-ink-recognition/example/android/app/build.gradle
+++ b/packages/digital-ink-recognition/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/entity-extraction/android/build.gradle
+++ b/packages/entity-extraction/android/build.gradle
@@ -31,7 +31,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/entity-extraction/example/android/app/build.gradle
+++ b/packages/entity-extraction/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/genai-image-description/example/android/app/build.gradle
+++ b/packages/genai-image-description/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/genai-prompt/example/android/app/build.gradle
+++ b/packages/genai-prompt/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/genai-proofreading/example/android/app/build.gradle
+++ b/packages/genai-proofreading/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/genai-rewriting/example/android/app/build.gradle
+++ b/packages/genai-rewriting/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/genai-speech-recognition/android/build.gradle
+++ b/packages/genai-speech-recognition/android/build.gradle
@@ -34,7 +34,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/genai-speech-recognition/example/android/app/build.gradle
+++ b/packages/genai-speech-recognition/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/genai-summarization/example/android/app/build.gradle
+++ b/packages/genai-summarization/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/image-labeling/android/build.gradle
+++ b/packages/image-labeling/android/build.gradle
@@ -31,7 +31,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/image-labeling/example/android/app/build.gradle
+++ b/packages/image-labeling/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/language-identification/android/build.gradle
+++ b/packages/language-identification/android/build.gradle
@@ -31,7 +31,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/language-identification/example/android/app/build.gradle
+++ b/packages/language-identification/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/object-detection/android/build.gradle
+++ b/packages/object-detection/android/build.gradle
@@ -31,7 +31,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/object-detection/example/android/app/build.gradle
+++ b/packages/object-detection/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/pose-detection/android/build.gradle
+++ b/packages/pose-detection/android/build.gradle
@@ -32,7 +32,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/pose-detection/example/android/app/build.gradle
+++ b/packages/pose-detection/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/smart-reply/android/build.gradle
+++ b/packages/smart-reply/android/build.gradle
@@ -31,7 +31,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/smart-reply/example/android/app/build.gradle
+++ b/packages/smart-reply/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/text-recognition/android/build.gradle
+++ b/packages/text-recognition/android/build.gradle
@@ -35,7 +35,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/text-recognition/example/android/app/build.gradle
+++ b/packages/text-recognition/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }


### PR DESCRIPTION
## Description

Android Gradle Plugin 9.3.0 no longer supports `getDefaultProguardFile('proguard-android.txt')` because it includes `-dontoptimize`, which prevents R8 from performing many optimizations. Builds using AGP 9.3.0 fail with:

> `getDefaultProguardFile('proguard-android.txt')` is no longer supported since it includes `-dontoptimize` [...] Instead use `getDefaultProguardFile('proguard-android-optimize.txt')`.

This switches all affected `build.gradle` files (plugins and example apps) from `proguard-android.txt` to the recommended `proguard-android-optimize.txt`.