### PR TITLE
chore(deps): update `@capacitor/cli`, `rollup`, `prettier-plugin-java` and `turbo`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,8 @@
         "patch-package": "8.0.1",
         "pkg-pr-new": "0.0.20",
         "prettier": "3.4.2",
-        "prettier-plugin-java": "2.6.7",
-        "turbo": "2.6.3"
+        "prettier-plugin-java": "2.9.7",
+        "turbo": "2.10.7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -152,9 +152,9 @@
       }
     },
     "node_modules/@capacitor/cli": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-8.0.0.tgz",
-      "integrity": "sha512-v9hEBi69xGxuuZhg55N031bMEenKaPSv71Il8C22VOOH6surDyv/MPeImN0oVfFc7eiklaW3rDFYVz6cmXfJWQ==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-8.4.2.tgz",
+      "integrity": "sha512-hE4HmpMdr5T8eQ++kGa1BKkdG2JLEvo1y1cj1kmFK78VB9dBp538oe1EZvzwupNGOl0ZueALotzL5wcXRD9w1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -166,13 +166,13 @@
         "env-paths": "^2.2.0",
         "fs-extra": "^11.2.0",
         "kleur": "^4.1.5",
-        "native-run": "^2.0.1",
+        "native-run": "^2.0.3",
         "open": "^8.4.0",
         "plist": "^3.1.0",
         "prompts": "^2.4.2",
         "rimraf": "^6.0.1",
         "semver": "^7.6.3",
-        "tar": "^6.1.11",
+        "tar": "^7.5.3",
         "tslib": "^2.8.1",
         "xml2js": "^0.6.2"
       },
@@ -733,50 +733,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/@chevrotain/cst-dts-gen": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz",
-      "integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/gast": "11.0.3",
-        "@chevrotain/types": "11.0.3",
-        "lodash-es": "4.17.21"
-      }
-    },
-    "node_modules/@chevrotain/gast": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
-      "integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/types": "11.0.3",
-        "lodash-es": "4.17.21"
-      }
-    },
-    "node_modules/@chevrotain/regexp-to-ast": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.0.3.tgz",
-      "integrity": "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@chevrotain/types": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz",
-      "integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@chevrotain/utils": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
-      "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
@@ -1071,27 +1027,17 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@isaacs/balanced-match": {
+    "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-      "dev": true,
-      "license": "MIT",
+      "license": "ISC",
       "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
+        "minipass": "^7.0.4"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@jsdevtools/ez-spawn": {
@@ -1552,9 +1498,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz",
-      "integrity": "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.3.tgz",
+      "integrity": "sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw==",
       "cpu": [
         "arm"
       ],
@@ -1566,9 +1512,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.3.tgz",
-      "integrity": "sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.3.tgz",
+      "integrity": "sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA==",
       "cpu": [
         "arm64"
       ],
@@ -1580,9 +1526,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.3.tgz",
-      "integrity": "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.3.tgz",
+      "integrity": "sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ==",
       "cpu": [
         "arm64"
       ],
@@ -1594,9 +1540,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.3.tgz",
-      "integrity": "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.3.tgz",
+      "integrity": "sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g==",
       "cpu": [
         "x64"
       ],
@@ -1608,9 +1554,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.3.tgz",
-      "integrity": "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.3.tgz",
+      "integrity": "sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ==",
       "cpu": [
         "arm64"
       ],
@@ -1622,9 +1568,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.3.tgz",
-      "integrity": "sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.3.tgz",
+      "integrity": "sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw==",
       "cpu": [
         "x64"
       ],
@@ -1636,13 +1582,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.3.tgz",
-      "integrity": "sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.3.tgz",
+      "integrity": "sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1650,13 +1599,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.3.tgz",
-      "integrity": "sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.3.tgz",
+      "integrity": "sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1664,13 +1616,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.3.tgz",
-      "integrity": "sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.3.tgz",
+      "integrity": "sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1678,13 +1633,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.3.tgz",
-      "integrity": "sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.3.tgz",
+      "integrity": "sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1692,13 +1650,33 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.3.tgz",
-      "integrity": "sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.3.tgz",
+      "integrity": "sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.3.tgz",
+      "integrity": "sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1706,13 +1684,33 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.3.tgz",
-      "integrity": "sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.3.tgz",
+      "integrity": "sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.3.tgz",
+      "integrity": "sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1720,13 +1718,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.3.tgz",
-      "integrity": "sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.3.tgz",
+      "integrity": "sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1734,13 +1735,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.3.tgz",
-      "integrity": "sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.3.tgz",
+      "integrity": "sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1748,13 +1752,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.3.tgz",
-      "integrity": "sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.3.tgz",
+      "integrity": "sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1762,13 +1769,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz",
-      "integrity": "sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1776,9 +1786,26 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.3.tgz",
-      "integrity": "sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.3.tgz",
+      "integrity": "sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.3.tgz",
+      "integrity": "sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==",
       "cpu": [
         "x64"
       ],
@@ -1786,13 +1813,13 @@
       "license": "MIT",
       "optional": true,
       "os": [
-        "linux"
+        "openbsd"
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.3.tgz",
-      "integrity": "sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.3.tgz",
+      "integrity": "sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg==",
       "cpu": [
         "arm64"
       ],
@@ -1804,9 +1831,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.3.tgz",
-      "integrity": "sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.3.tgz",
+      "integrity": "sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA==",
       "cpu": [
         "arm64"
       ],
@@ -1818,9 +1845,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.3.tgz",
-      "integrity": "sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.3.tgz",
+      "integrity": "sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ==",
       "cpu": [
         "ia32"
       ],
@@ -1832,9 +1859,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.3.tgz",
-      "integrity": "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ==",
       "cpu": [
         "x64"
       ],
@@ -1846,9 +1873,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.3.tgz",
-      "integrity": "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.3.tgz",
+      "integrity": "sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g==",
       "cpu": [
         "x64"
       ],
@@ -1866,10 +1893,94 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@turbo/darwin-64": {
+      "version": "2.10.7",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.10.7.tgz",
+      "integrity": "sha512-/c9cSBRermWDv85oufLhoH6XRLOVbvzJLRd+WLyfJCP+i0HFLQj4PVNDrHcY17/ve5l8X0Oua4bJBqJUgJPnZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@turbo/darwin-arm64": {
+      "version": "2.10.7",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.10.7.tgz",
+      "integrity": "sha512-8lpCCGWZBl9PIF8w8f2iEWrLMbHBWIfJeV6l2UEGqysD6HRIM4ySj/8R7HGEzbECJ4r/gnJcHmxEoG8yjFe64A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@turbo/linux-64": {
+      "version": "2.10.7",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.10.7.tgz",
+      "integrity": "sha512-Midw9Ed00yw9rqkWN82fY3LmLNFQ6yiL1GXB56DJKUEjWaEd27zh7ohCxzzrjfjQVrEeVWd3UPytTAV16XDQlA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@turbo/linux-arm64": {
+      "version": "2.10.7",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.10.7.tgz",
+      "integrity": "sha512-UVEy+MW/xn4BcsiV3v3uv0/oObyaQgVtRT+Jj4WE53rNH05VEYEc1Z13q3zV6276wCZR4Yxc4hiTTcjw7PjSpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@turbo/windows-64": {
+      "version": "2.10.7",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.10.7.tgz",
+      "integrity": "sha512-l2nH9KGLV46SWjcXvyc2+xo5gdf5J0NVADknQk9OCJhzJBpiNl/byd26yIfwZBjLupdqT6UOdPhPxcpUPxRykQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@turbo/windows-arm64": {
+      "version": "2.10.7",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.10.7.tgz",
+      "integrity": "sha512-qjE1apG6RThuX49vUJd5ks2dV2ndXC2qktDChQonFMvUzrMrEnZMQzO+IgxBiYq1j+NbXQcRwj84nGnk1TBw1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1898,13 +2009,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.2.tgz",
-      "integrity": "sha512-gWEkeiyYE4vqjON/+Obqcoeffmk0NF15WSBwSs7zwVA2bAbTaE0SJ7P0WNGoJn8uE7fiaV5a7dKYIJriEqOrmA==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/semver": {
@@ -2125,13 +2236,13 @@
       "license": "ISC"
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.6"
       }
     },
     "node_modules/@yarnpkg/lockfile": {
@@ -2614,42 +2725,14 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/chevrotain": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
-      "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/cst-dts-gen": "11.0.3",
-        "@chevrotain/gast": "11.0.3",
-        "@chevrotain/regexp-to-ast": "11.0.3",
-        "@chevrotain/types": "11.0.3",
-        "@chevrotain/utils": "11.0.3",
-        "lodash-es": "4.17.21"
-      }
-    },
-    "node_modules/chevrotain-allstar": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
-      "integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash-es": "^4.17.21"
-      },
-      "peerDependencies": {
-        "chevrotain": "^11.0.0"
-      }
-    },
     "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/ci-info": {
@@ -2761,9 +2844,9 @@
       }
     },
     "node_modules/cli-truncate/node_modules/string-width": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
-      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3992,9 +4075,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.3.2",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.2.tgz",
-      "integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4004,32 +4087,6 @@
       },
       "engines": {
         "node": ">=14.14"
-      }
-    },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/fs.realpath": {
@@ -4196,18 +4253,18 @@
       "license": "ISC"
     },
     "node_modules/glob": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
-      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "path-scurry": "^2.0.0"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -4226,17 +4283,40 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "balanced-match": "^4.0.2"
       },
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -5072,18 +5152,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/java-parser": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/java-parser/-/java-parser-2.3.3.tgz",
-      "integrity": "sha512-9YY8OGlNGfq5TDDq2SBjtIEHMVLeV8vSSZrXDaQBhQ84hi1zc3/+5l3DF3wW8JGqQT2kNVha05dziSamvN8M/g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "chevrotain": "11.0.3",
-        "chevrotain-allstar": "0.3.1",
-        "lodash": "4.17.21"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5092,10 +5160,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -5166,9 +5244,9 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5265,9 +5343,9 @@
       }
     },
     "node_modules/lint-staged/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5321,9 +5399,9 @@
       }
     },
     "node_modules/listr2/node_modules/string-width": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
-      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5383,20 +5461,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -5551,9 +5615,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.2.4",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
-      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -5625,9 +5689,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5648,53 +5712,26 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": ">= 18"
       }
     },
     "node_modules/mlly": {
@@ -5728,9 +5765,9 @@
       "license": "MIT"
     },
     "node_modules/native-run": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/native-run/-/native-run-2.0.1.tgz",
-      "integrity": "sha512-XfG1FBZLM50J10xH9361whJRC9SHZ0Bub4iNRhhI61C8Jv0e1ud19muex6sNKB51ibQNUJNuYn25MuYET/rE6w==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/native-run/-/native-run-2.0.3.tgz",
+      "integrity": "sha512-U1PllBuzW5d1gfan+88L+Hky2eZx+9gv3Pf6rNBxKbORxi7boHzqiA6QFGSnqMem4j0A9tZ08NMIs5+0m/VS1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6206,9 +6243,9 @@
       "license": "MIT"
     },
     "node_modules/path-scurry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
-      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -6216,7 +6253,7 @@
         "minipass": "^7.1.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -6254,9 +6291,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6309,13 +6346,13 @@
       }
     },
     "node_modules/plist": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
-      "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.1.tgz",
+      "integrity": "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@xmldom/xmldom": "^0.8.8",
+        "@xmldom/xmldom": "^0.9.10",
         "base64-js": "^1.5.1",
         "xmlbuilder": "^15.1.1"
       },
@@ -6360,14 +6397,13 @@
       }
     },
     "node_modules/prettier-plugin-java": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-java/-/prettier-plugin-java-2.6.7.tgz",
-      "integrity": "sha512-AVm+X7fhAZpYKiUCdUIGZ8HJbkGkTUgYQIKVuCQEplcqpGw2ewVnNGcPb1Kc3+MYMfiEqzhd8ZYhMGVHw6tZdQ==",
+      "version": "2.9.7",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-java/-/prettier-plugin-java-2.9.7.tgz",
+      "integrity": "sha512-5ifIseGcpuBizlGw9bUZPoyRPj8c9TV2g2jfO+70Dt92ZH5XG39iXZ4qyGTXN7OTdEprqJjHYQ8UWZcfDc4P9Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "java-parser": "2.3.3",
-        "lodash": "4.17.21"
+        "web-tree-sitter": "0.26.9"
       },
       "peerDependencies": {
         "prettier": "^3.0.0"
@@ -6521,9 +6557,9 @@
       }
     },
     "node_modules/read-yaml-file/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6709,13 +6745,13 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
-      "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.3.tgz",
+      "integrity": "sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -6725,28 +6761,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.53.3",
-        "@rollup/rollup-android-arm64": "4.53.3",
-        "@rollup/rollup-darwin-arm64": "4.53.3",
-        "@rollup/rollup-darwin-x64": "4.53.3",
-        "@rollup/rollup-freebsd-arm64": "4.53.3",
-        "@rollup/rollup-freebsd-x64": "4.53.3",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.53.3",
-        "@rollup/rollup-linux-arm-musleabihf": "4.53.3",
-        "@rollup/rollup-linux-arm64-gnu": "4.53.3",
-        "@rollup/rollup-linux-arm64-musl": "4.53.3",
-        "@rollup/rollup-linux-loong64-gnu": "4.53.3",
-        "@rollup/rollup-linux-ppc64-gnu": "4.53.3",
-        "@rollup/rollup-linux-riscv64-gnu": "4.53.3",
-        "@rollup/rollup-linux-riscv64-musl": "4.53.3",
-        "@rollup/rollup-linux-s390x-gnu": "4.53.3",
-        "@rollup/rollup-linux-x64-gnu": "4.53.3",
-        "@rollup/rollup-linux-x64-musl": "4.53.3",
-        "@rollup/rollup-openharmony-arm64": "4.53.3",
-        "@rollup/rollup-win32-arm64-msvc": "4.53.3",
-        "@rollup/rollup-win32-ia32-msvc": "4.53.3",
-        "@rollup/rollup-win32-x64-gnu": "4.53.3",
-        "@rollup/rollup-win32-x64-msvc": "4.53.3",
+        "@rollup/rollup-android-arm-eabi": "4.62.3",
+        "@rollup/rollup-android-arm64": "4.62.3",
+        "@rollup/rollup-darwin-arm64": "4.62.3",
+        "@rollup/rollup-darwin-x64": "4.62.3",
+        "@rollup/rollup-freebsd-arm64": "4.62.3",
+        "@rollup/rollup-freebsd-x64": "4.62.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.3",
+        "@rollup/rollup-linux-arm64-musl": "4.62.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.3",
+        "@rollup/rollup-linux-loong64-musl": "4.62.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-musl": "4.62.3",
+        "@rollup/rollup-openbsd-x64": "4.62.3",
+        "@rollup/rollup-openharmony-arm64": "4.62.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.3",
+        "@rollup/rollup-win32-x64-gnu": "4.62.3",
+        "@rollup/rollup-win32-x64-msvc": "4.62.3",
         "fsevents": "~2.3.2"
       }
     },
@@ -6865,9 +6904,9 @@
       "license": "ISC"
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -7318,31 +7357,20 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
+        "node": ">=18"
       }
     },
     "node_modules/term-size": {
@@ -7469,106 +7497,22 @@
       "license": "0BSD"
     },
     "node_modules/turbo": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.6.3.tgz",
-      "integrity": "sha512-bf6YKUv11l5Xfcmg76PyWoy/e2vbkkxFNBGJSnfdSXQC33ZiUfutYh6IXidc5MhsnrFkWfdNNLyaRk+kHMLlwA==",
+      "version": "2.10.7",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.10.7.tgz",
+      "integrity": "sha512-GHx6WExIFSKNJ5qMlzDpXBXlu9ApxaMjqxAVrCNcW94xf/+uqgIz41SAuRUMbXva2ExNAaY/h8V0q90SWSzmRw==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "2.6.3",
-        "turbo-darwin-arm64": "2.6.3",
-        "turbo-linux-64": "2.6.3",
-        "turbo-linux-arm64": "2.6.3",
-        "turbo-windows-64": "2.6.3",
-        "turbo-windows-arm64": "2.6.3"
+        "@turbo/darwin-64": "2.10.7",
+        "@turbo/darwin-arm64": "2.10.7",
+        "@turbo/linux-64": "2.10.7",
+        "@turbo/linux-arm64": "2.10.7",
+        "@turbo/windows-64": "2.10.7",
+        "@turbo/windows-arm64": "2.10.7"
       }
-    },
-    "node_modules/turbo-darwin-64": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.6.3.tgz",
-      "integrity": "sha512-BlJJDc1CQ7SK5Y5qnl7AzpkvKSnpkfPmnA+HeU/sgny3oHZckPV2776ebO2M33CYDSor7+8HQwaodY++IINhYg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/turbo-darwin-arm64": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.6.3.tgz",
-      "integrity": "sha512-MwVt7rBKiOK7zdYerenfCRTypefw4kZCue35IJga9CH1+S50+KTiCkT6LBqo0hHeoH2iKuI0ldTF2a0aB72z3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/turbo-linux-64": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.6.3.tgz",
-      "integrity": "sha512-cqpcw+dXxbnPtNnzeeSyWprjmuFVpHJqKcs7Jym5oXlu/ZcovEASUIUZVN3OGEM6Y/OTyyw0z09tOHNt5yBAVg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/turbo-linux-arm64": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.6.3.tgz",
-      "integrity": "sha512-MterpZQmjXyr4uM7zOgFSFL3oRdNKeflY7nsjxJb2TklsYqiu3Z9pQ4zRVFFH8n0mLGna7MbQMZuKoWqqHb45w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/turbo-windows-64": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.6.3.tgz",
-      "integrity": "sha512-biDU70v9dLwnBdLf+daoDlNJVvqOOP8YEjqNipBHzgclbQlXbsi6Gqqelp5er81Qo3BiRgmTNx79oaZQTPb07Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/turbo-windows-arm64": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.6.3.tgz",
-      "integrity": "sha512-dDHVKpSeukah3VsI/xMEKeTnV9V9cjlpFSUs4bmsUiLu3Yv2ENlgVEZv65wxbeE0bh0jjpmElDT+P1KaCxArQQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -7735,9 +7679,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7804,6 +7748,13 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/web-tree-sitter": {
+      "version": "0.26.9",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.9.tgz",
+      "integrity": "sha512-YJwSHANl6XFgeEjB8nitgj0qZYt5gkIesJ4w2srS2wcLB4GUa4xcOkM0YaMsU6WNR53YVIkDSY7Ej4pf3IXtCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -7998,11 +7949,14 @@
       }
     },
     "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
       "dev": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/yaml": {
       "version": "2.9.0",
@@ -8083,15 +8037,15 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@capacitor/android": "8.0.0",
-        "@capacitor/cli": "8.0.0",
+        "@capacitor/cli": "8.4.2",
         "@capacitor/core": "8.0.0",
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier-plugin-java": "2.6.7",
+        "prettier-plugin-java": "2.9.7",
         "rimraf": "6.1.2",
-        "rollup": "4.53.3",
+        "rollup": "4.62.3",
         "swiftlint": "2.0.0",
         "typescript": "5.9.3"
       },
@@ -8101,7 +8055,7 @@
     },
     "packages/digital-ink-recognition": {
       "name": "@capacitor-mlkit/digital-ink-recognition",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "funding": [
         {
           "type": "github",
@@ -8115,15 +8069,15 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@capacitor/android": "8.0.0",
-        "@capacitor/cli": "8.0.0",
+        "@capacitor/cli": "8.4.2",
         "@capacitor/core": "8.0.0",
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier-plugin-java": "2.6.7",
+        "prettier-plugin-java": "2.9.7",
         "rimraf": "6.1.2",
-        "rollup": "4.53.3",
+        "rollup": "4.62.3",
         "swiftlint": "2.0.0",
         "typescript": "5.9.3"
       },
@@ -8147,15 +8101,15 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@capacitor/android": "8.0.0",
-        "@capacitor/cli": "8.0.0",
+        "@capacitor/cli": "8.4.2",
         "@capacitor/core": "8.0.0",
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier-plugin-java": "2.6.7",
+        "prettier-plugin-java": "2.9.7",
         "rimraf": "6.1.2",
-        "rollup": "4.53.3",
+        "rollup": "4.62.3",
         "swiftlint": "2.0.0",
         "typescript": "5.9.3"
       },
@@ -8165,7 +8119,7 @@
     },
     "packages/entity-extraction": {
       "name": "@capacitor-mlkit/entity-extraction",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "funding": [
         {
           "type": "github",
@@ -8179,15 +8133,15 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@capacitor/android": "8.0.0",
-        "@capacitor/cli": "8.0.0",
+        "@capacitor/cli": "8.4.2",
         "@capacitor/core": "8.0.0",
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier-plugin-java": "2.6.7",
+        "prettier-plugin-java": "2.9.7",
         "rimraf": "6.1.2",
-        "rollup": "4.53.3",
+        "rollup": "4.62.3",
         "swiftlint": "2.0.0",
         "typescript": "5.9.3"
       },
@@ -8211,15 +8165,15 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@capacitor/android": "8.0.0",
-        "@capacitor/cli": "8.0.0",
+        "@capacitor/cli": "8.4.2",
         "@capacitor/core": "8.0.0",
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier-plugin-java": "2.6.7",
+        "prettier-plugin-java": "2.9.7",
         "rimraf": "6.1.2",
-        "rollup": "4.53.3",
+        "rollup": "4.62.3",
         "swiftlint": "2.0.0",
         "typescript": "5.9.3"
       },
@@ -8243,15 +8197,15 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@capacitor/android": "8.0.0",
-        "@capacitor/cli": "8.0.0",
+        "@capacitor/cli": "8.4.2",
         "@capacitor/core": "8.0.0",
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier-plugin-java": "2.6.7",
+        "prettier-plugin-java": "2.9.7",
         "rimraf": "6.1.2",
-        "rollup": "4.53.3",
+        "rollup": "4.62.3",
         "swiftlint": "2.0.0",
         "typescript": "5.9.3"
       },
@@ -8261,7 +8215,7 @@
     },
     "packages/genai-image-description": {
       "name": "@capacitor-mlkit/genai-image-description",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "funding": [
         {
           "type": "github",
@@ -8275,15 +8229,15 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@capacitor/android": "8.0.0",
-        "@capacitor/cli": "8.0.0",
+        "@capacitor/cli": "8.4.2",
         "@capacitor/core": "8.0.0",
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier-plugin-java": "2.6.7",
+        "prettier-plugin-java": "2.9.7",
         "rimraf": "6.1.2",
-        "rollup": "4.53.3",
+        "rollup": "4.62.3",
         "swiftlint": "2.0.0",
         "typescript": "5.9.3"
       },
@@ -8293,7 +8247,7 @@
     },
     "packages/genai-prompt": {
       "name": "@capacitor-mlkit/genai-prompt",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "funding": [
         {
           "type": "github",
@@ -8307,15 +8261,15 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@capacitor/android": "8.0.0",
-        "@capacitor/cli": "8.0.0",
+        "@capacitor/cli": "8.4.2",
         "@capacitor/core": "8.0.0",
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier-plugin-java": "2.6.7",
+        "prettier-plugin-java": "2.9.7",
         "rimraf": "6.1.2",
-        "rollup": "4.53.3",
+        "rollup": "4.62.3",
         "swiftlint": "2.0.0",
         "typescript": "5.9.3"
       },
@@ -8325,7 +8279,7 @@
     },
     "packages/genai-proofreading": {
       "name": "@capacitor-mlkit/genai-proofreading",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "funding": [
         {
           "type": "github",
@@ -8339,15 +8293,15 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@capacitor/android": "8.0.0",
-        "@capacitor/cli": "8.0.0",
+        "@capacitor/cli": "8.4.2",
         "@capacitor/core": "8.0.0",
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier-plugin-java": "2.6.7",
+        "prettier-plugin-java": "2.9.7",
         "rimraf": "6.1.2",
-        "rollup": "4.53.3",
+        "rollup": "4.62.3",
         "swiftlint": "2.0.0",
         "typescript": "5.9.3"
       },
@@ -8357,7 +8311,7 @@
     },
     "packages/genai-rewriting": {
       "name": "@capacitor-mlkit/genai-rewriting",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "funding": [
         {
           "type": "github",
@@ -8371,15 +8325,15 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@capacitor/android": "8.0.0",
-        "@capacitor/cli": "8.0.0",
+        "@capacitor/cli": "8.4.2",
         "@capacitor/core": "8.0.0",
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier-plugin-java": "2.6.7",
+        "prettier-plugin-java": "2.9.7",
         "rimraf": "6.1.2",
-        "rollup": "4.53.3",
+        "rollup": "4.62.3",
         "swiftlint": "2.0.0",
         "typescript": "5.9.3"
       },
@@ -8389,7 +8343,7 @@
     },
     "packages/genai-speech-recognition": {
       "name": "@capacitor-mlkit/genai-speech-recognition",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "funding": [
         {
           "type": "github",
@@ -8403,15 +8357,15 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@capacitor/android": "8.0.0",
-        "@capacitor/cli": "8.0.0",
+        "@capacitor/cli": "8.4.2",
         "@capacitor/core": "8.0.0",
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier-plugin-java": "2.6.7",
+        "prettier-plugin-java": "2.9.7",
         "rimraf": "6.1.2",
-        "rollup": "4.53.3",
+        "rollup": "4.62.3",
         "swiftlint": "2.0.0",
         "typescript": "5.9.3"
       },
@@ -8421,7 +8375,7 @@
     },
     "packages/genai-summarization": {
       "name": "@capacitor-mlkit/genai-summarization",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "funding": [
         {
           "type": "github",
@@ -8435,15 +8389,15 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@capacitor/android": "8.0.0",
-        "@capacitor/cli": "8.0.0",
+        "@capacitor/cli": "8.4.2",
         "@capacitor/core": "8.0.0",
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier-plugin-java": "2.6.7",
+        "prettier-plugin-java": "2.9.7",
         "rimraf": "6.1.2",
-        "rollup": "4.53.3",
+        "rollup": "4.62.3",
         "swiftlint": "2.0.0",
         "typescript": "5.9.3"
       },
@@ -8453,7 +8407,7 @@
     },
     "packages/image-labeling": {
       "name": "@capacitor-mlkit/image-labeling",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "funding": [
         {
           "type": "github",
@@ -8467,15 +8421,15 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@capacitor/android": "8.0.0",
-        "@capacitor/cli": "8.0.0",
+        "@capacitor/cli": "8.4.2",
         "@capacitor/core": "8.0.0",
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier-plugin-java": "2.6.7",
+        "prettier-plugin-java": "2.9.7",
         "rimraf": "6.1.2",
-        "rollup": "4.53.3",
+        "rollup": "4.62.3",
         "swiftlint": "2.0.0",
         "typescript": "5.9.3"
       },
@@ -8485,7 +8439,7 @@
     },
     "packages/language-identification": {
       "name": "@capacitor-mlkit/language-identification",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "funding": [
         {
           "type": "github",
@@ -8499,15 +8453,15 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@capacitor/android": "8.0.0",
-        "@capacitor/cli": "8.0.0",
+        "@capacitor/cli": "8.4.2",
         "@capacitor/core": "8.0.0",
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier-plugin-java": "2.6.7",
+        "prettier-plugin-java": "2.9.7",
         "rimraf": "6.1.2",
-        "rollup": "4.53.3",
+        "rollup": "4.62.3",
         "swiftlint": "2.0.0",
         "typescript": "5.9.3"
       },
@@ -8517,7 +8471,7 @@
     },
     "packages/object-detection": {
       "name": "@capacitor-mlkit/object-detection",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "funding": [
         {
           "type": "github",
@@ -8531,15 +8485,15 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@capacitor/android": "8.0.0",
-        "@capacitor/cli": "8.0.0",
+        "@capacitor/cli": "8.4.2",
         "@capacitor/core": "8.0.0",
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier-plugin-java": "2.6.7",
+        "prettier-plugin-java": "2.9.7",
         "rimraf": "6.1.2",
-        "rollup": "4.53.3",
+        "rollup": "4.62.3",
         "swiftlint": "2.0.0",
         "typescript": "5.9.3"
       },
@@ -8549,7 +8503,7 @@
     },
     "packages/pose-detection": {
       "name": "@capacitor-mlkit/pose-detection",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "funding": [
         {
           "type": "github",
@@ -8563,15 +8517,15 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@capacitor/android": "8.0.0",
-        "@capacitor/cli": "8.0.0",
+        "@capacitor/cli": "8.4.2",
         "@capacitor/core": "8.0.0",
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier-plugin-java": "2.6.7",
+        "prettier-plugin-java": "2.9.7",
         "rimraf": "6.1.2",
-        "rollup": "4.53.3",
+        "rollup": "4.62.3",
         "swiftlint": "2.0.0",
         "typescript": "5.9.3"
       },
@@ -8595,15 +8549,15 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@capacitor/android": "8.0.0",
-        "@capacitor/cli": "8.0.0",
+        "@capacitor/cli": "8.4.2",
         "@capacitor/core": "8.0.0",
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier-plugin-java": "2.6.7",
+        "prettier-plugin-java": "2.9.7",
         "rimraf": "6.1.2",
-        "rollup": "4.53.3",
+        "rollup": "4.62.3",
         "swiftlint": "2.0.0",
         "typescript": "5.9.3"
       },
@@ -8613,7 +8567,7 @@
     },
     "packages/smart-reply": {
       "name": "@capacitor-mlkit/smart-reply",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "funding": [
         {
           "type": "github",
@@ -8627,15 +8581,15 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@capacitor/android": "8.0.0",
-        "@capacitor/cli": "8.0.0",
+        "@capacitor/cli": "8.4.2",
         "@capacitor/core": "8.0.0",
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier-plugin-java": "2.6.7",
+        "prettier-plugin-java": "2.9.7",
         "rimraf": "6.1.2",
-        "rollup": "4.53.3",
+        "rollup": "4.62.3",
         "swiftlint": "2.0.0",
         "typescript": "5.9.3"
       },
@@ -8659,15 +8613,15 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@capacitor/android": "8.0.0",
-        "@capacitor/cli": "8.0.0",
+        "@capacitor/cli": "8.4.2",
         "@capacitor/core": "8.0.0",
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier-plugin-java": "2.6.7",
+        "prettier-plugin-java": "2.9.7",
         "rimraf": "6.1.2",
-        "rollup": "4.53.3",
+        "rollup": "4.62.3",
         "swiftlint": "2.0.0",
         "typescript": "5.9.3"
       },
@@ -8677,7 +8631,7 @@
     },
     "packages/text-recognition": {
       "name": "@capacitor-mlkit/text-recognition",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "funding": [
         {
           "type": "github",
@@ -8691,15 +8645,15 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@capacitor/android": "8.0.0",
-        "@capacitor/cli": "8.0.0",
+        "@capacitor/cli": "8.4.2",
         "@capacitor/core": "8.0.0",
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier-plugin-java": "2.6.7",
+        "prettier-plugin-java": "2.9.7",
         "rimraf": "6.1.2",
-        "rollup": "4.53.3",
+        "rollup": "4.62.3",
         "swiftlint": "2.0.0",
         "typescript": "5.9.3"
       },
@@ -8723,15 +8677,15 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@capacitor/android": "8.0.0",
-        "@capacitor/cli": "8.0.0",
+        "@capacitor/cli": "8.4.2",
         "@capacitor/core": "8.0.0",
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier-plugin-java": "2.6.7",
+        "prettier-plugin-java": "2.9.7",
         "rimraf": "6.1.2",
-        "rollup": "4.53.3",
+        "rollup": "4.62.3",
         "swiftlint": "2.0.0",
         "typescript": "5.9.3"
       },

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "patch-package": "8.0.1",
     "pkg-pr-new": "0.0.20",
     "prettier": "3.4.2",
-    "prettier-plugin-java": "2.6.7",
-    "turbo": "2.6.3"
+    "prettier-plugin-java": "2.9.7",
+    "turbo": "2.10.7"
   },
   "overrides": {
     "zod-package-json": "1.0.3"

--- a/packages/barcode-scanning/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/barcodescanning/BarcodeScanner.java
+++ b/packages/barcode-scanning/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/barcodescanning/BarcodeScanner.java
@@ -122,41 +122,38 @@ public class BarcodeScanner implements ImageAnalysis.Analyzer {
         imageAnalysis.setAnalyzer(ContextCompat.getMainExecutor(plugin.getContext()), this);
 
         ListenableFuture<ProcessCameraProvider> cameraProviderFuture = ProcessCameraProvider.getInstance(plugin.getContext());
-        cameraProviderFuture.addListener(
-            () -> {
-                try {
-                    processCameraProvider = cameraProviderFuture.get();
+        cameraProviderFuture.addListener(() -> {
+            try {
+                processCameraProvider = cameraProviderFuture.get();
 
-                    CameraSelector cameraSelector = new CameraSelector.Builder().requireLensFacing(this.scanSettings.lensFacing).build();
+                CameraSelector cameraSelector = new CameraSelector.Builder().requireLensFacing(this.scanSettings.lensFacing).build();
 
-                    previewView = new PreviewView(plugin.getActivity());
-                    previewView.setLayoutParams(
-                        new FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT)
-                    );
-                    previewView.setScaleType(PreviewView.ScaleType.FILL_CENTER);
-                    previewView.setBackgroundColor(Color.BLACK);
+                previewView = new PreviewView(plugin.getActivity());
+                previewView.setLayoutParams(
+                    new FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT)
+                );
+                previewView.setScaleType(PreviewView.ScaleType.FILL_CENTER);
+                previewView.setBackgroundColor(Color.BLACK);
 
-                    // Add preview view behind the WebView
-                    ((ViewGroup) plugin.getBridge().getWebView().getParent()).addView(previewView, 0);
+                // Add preview view behind the WebView
+                ((ViewGroup) plugin.getBridge().getWebView().getParent()).addView(previewView, 0);
 
-                    Preview preview = new Preview.Builder().build();
-                    preview.setSurfaceProvider(previewView.getSurfaceProvider());
+                Preview preview = new Preview.Builder().build();
+                preview.setSurfaceProvider(previewView.getSurfaceProvider());
 
-                    // Start the camera
-                    camera = processCameraProvider.bindToLifecycle(
-                        (LifecycleOwner) plugin.getContext(),
-                        cameraSelector,
-                        preview,
-                        imageAnalysis
-                    );
+                // Start the camera
+                camera = processCameraProvider.bindToLifecycle(
+                    (LifecycleOwner) plugin.getContext(),
+                    cameraSelector,
+                    preview,
+                    imageAnalysis
+                );
 
-                    callback.success();
-                } catch (Exception exception) {
-                    callback.error(exception);
-                }
-            },
-            ContextCompat.getMainExecutor(plugin.getContext())
-        );
+                callback.success();
+            } catch (Exception exception) {
+                callback.error(exception);
+            }
+        }, ContextCompat.getMainExecutor(plugin.getContext()));
     }
 
     /**

--- a/packages/barcode-scanning/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/barcodescanning/BarcodeScannerPlugin.java
+++ b/packages/barcode-scanning/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/barcodescanning/BarcodeScannerPlugin.java
@@ -84,24 +84,23 @@ public class BarcodeScannerPlugin extends Plugin {
                 return;
             }
 
-            getActivity()
-                .runOnUiThread(() -> {
-                    implementation.startScan(
-                        scanSettings,
-                        new StartScanResultCallback() {
-                            @Override
-                            public void success() {
-                                call.resolve();
-                            }
-
-                            @Override
-                            public void error(Exception exception) {
-                                Logger.error(TAG, exception.getMessage(), exception);
-                                call.reject(exception.getMessage());
-                            }
+            getActivity().runOnUiThread(() -> {
+                implementation.startScan(
+                    scanSettings,
+                    new StartScanResultCallback() {
+                        @Override
+                        public void success() {
+                            call.resolve();
                         }
-                    );
-                });
+
+                        @Override
+                        public void error(Exception exception) {
+                            Logger.error(TAG, exception.getMessage(), exception);
+                            call.reject(exception.getMessage());
+                        }
+                    }
+                );
+            });
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
             call.reject(exception.getMessage());
@@ -111,11 +110,10 @@ public class BarcodeScannerPlugin extends Plugin {
     @PluginMethod
     public void stopScan(PluginCall call) {
         try {
-            getActivity()
-                .runOnUiThread(() -> {
-                    implementation.stopScan();
-                    call.resolve();
-                });
+            getActivity().runOnUiThread(() -> {
+                implementation.stopScan();
+                call.resolve();
+            });
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
             call.reject(exception.getMessage());

--- a/packages/barcode-scanning/package.json
+++ b/packages/barcode-scanning/package.json
@@ -65,15 +65,15 @@
   },
   "devDependencies": {
     "@capacitor/android": "8.0.0",
-    "@capacitor/cli": "8.0.0",
+    "@capacitor/cli": "8.4.2",
     "@capacitor/core": "8.0.0",
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier-plugin-java": "2.6.7",
+    "prettier-plugin-java": "2.9.7",
     "rimraf": "6.1.2",
-    "rollup": "4.53.3",
+    "rollup": "4.62.3",
     "swiftlint": "2.0.0",
     "typescript": "5.9.3"
   },

--- a/packages/digital-ink-recognition/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/digitalinkrecognition/DigitalInkRecognition.java
+++ b/packages/digital-ink-recognition/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/digitalinkrecognition/DigitalInkRecognition.java
@@ -32,13 +32,19 @@ public class DigitalInkRecognition {
 
     public void deleteDownloadedModel(@NonNull DeleteDownloadedModelOptions options, @NonNull EmptyCallback callback) throws Exception {
         DigitalInkRecognitionModel model = createModel(options.getLanguageTag());
-        modelManager.deleteDownloadedModel(model).addOnSuccessListener(result -> callback.success()).addOnFailureListener(callback::error);
+        modelManager
+            .deleteDownloadedModel(model)
+            .addOnSuccessListener(result -> callback.success())
+            .addOnFailureListener(callback::error);
     }
 
     public void downloadModel(@NonNull DownloadModelOptions options, @NonNull EmptyCallback callback) throws Exception {
         DigitalInkRecognitionModel model = createModel(options.getLanguageTag());
         DownloadConditions conditions = new DownloadConditions.Builder().build();
-        modelManager.download(model, conditions).addOnSuccessListener(result -> callback.success()).addOnFailureListener(callback::error);
+        modelManager
+            .download(model, conditions)
+            .addOnSuccessListener(result -> callback.success())
+            .addOnFailureListener(callback::error);
     }
 
     public void getDownloadedModels(@NonNull NonEmptyResultCallback<GetDownloadedModelsResult> callback) {
@@ -64,18 +70,17 @@ public class DigitalInkRecognition {
                     recognizerOptions
                 );
                 RecognitionContext recognitionContext = createRecognitionContext(options.getPreContext(), options.getWritingArea());
-                Task<RecognitionResult> task = recognitionContext == null
-                    ? recognizer.recognize(options.getInk())
-                    : recognizer.recognize(options.getInk(), recognitionContext);
-                task
-                    .addOnSuccessListener(recognitionResult -> {
-                        recognizer.close();
-                        callback.success(new RecognizeResult(recognitionResult));
-                    })
-                    .addOnFailureListener(exception -> {
-                        recognizer.close();
-                        callback.error(exception);
-                    });
+                Task<RecognitionResult> task =
+                    recognitionContext == null
+                        ? recognizer.recognize(options.getInk())
+                        : recognizer.recognize(options.getInk(), recognitionContext);
+                task.addOnSuccessListener(recognitionResult -> {
+                    recognizer.close();
+                    callback.success(new RecognizeResult(recognitionResult));
+                }).addOnFailureListener(exception -> {
+                    recognizer.close();
+                    callback.error(exception);
+                });
             })
             .addOnFailureListener(callback::error);
     }

--- a/packages/digital-ink-recognition/package.json
+++ b/packages/digital-ink-recognition/package.json
@@ -57,15 +57,15 @@
   },
   "devDependencies": {
     "@capacitor/android": "8.0.0",
-    "@capacitor/cli": "8.0.0",
+    "@capacitor/cli": "8.4.2",
     "@capacitor/core": "8.0.0",
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier-plugin-java": "2.6.7",
+    "prettier-plugin-java": "2.9.7",
     "rimraf": "6.1.2",
-    "rollup": "4.53.3",
+    "rollup": "4.62.3",
     "swiftlint": "2.0.0",
     "typescript": "5.9.3"
   },

--- a/packages/document-scanner/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/documentscanner/DocumentScannerPlugin.java
+++ b/packages/document-scanner/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/documentscanner/DocumentScannerPlugin.java
@@ -39,8 +39,9 @@ public class DocumentScannerPlugin extends Plugin {
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
         }
-        scannerLauncher = getActivity()
-            .registerForActivityResult(new ActivityResultContracts.StartIntentSenderForResult(), activityResult -> {
+        scannerLauncher = getActivity().registerForActivityResult(
+            new ActivityResultContracts.StartIntentSenderForResult(),
+            activityResult -> {
                 if (savedCall == null) {
                     return;
                 }
@@ -76,7 +77,8 @@ public class DocumentScannerPlugin extends Plugin {
                     savedCall.reject("Scan cancelled or failed. Result code: " + activityResult.getResultCode());
                 }
                 savedCall = null;
-            });
+            }
+        );
     }
 
     @PluginMethod

--- a/packages/document-scanner/package.json
+++ b/packages/document-scanner/package.json
@@ -64,15 +64,15 @@
   },
   "devDependencies": {
     "@capacitor/android": "8.0.0",
-    "@capacitor/cli": "8.0.0",
+    "@capacitor/cli": "8.4.2",
     "@capacitor/core": "8.0.0",
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier-plugin-java": "2.6.7",
+    "prettier-plugin-java": "2.9.7",
     "rimraf": "6.1.2",
-    "rollup": "4.53.3",
+    "rollup": "4.62.3",
     "swiftlint": "2.0.0",
     "typescript": "5.9.3"
   },

--- a/packages/entity-extraction/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/entityextraction/EntityExtraction.java
+++ b/packages/entity-extraction/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/entityextraction/EntityExtraction.java
@@ -42,13 +42,19 @@ public class EntityExtraction {
 
     public void deleteDownloadedModel(@NonNull DeleteDownloadedModelOptions options, @NonNull EmptyCallback callback) {
         EntityExtractionRemoteModel model = new EntityExtractionRemoteModel.Builder(options.getModelIdentifier()).build();
-        modelManager.deleteDownloadedModel(model).addOnSuccessListener(unused -> callback.success()).addOnFailureListener(callback::error);
+        modelManager
+            .deleteDownloadedModel(model)
+            .addOnSuccessListener(unused -> callback.success())
+            .addOnFailureListener(callback::error);
     }
 
     public void downloadModel(@NonNull DownloadModelOptions options, @NonNull EmptyCallback callback) {
         EntityExtractionRemoteModel model = new EntityExtractionRemoteModel.Builder(options.getModelIdentifier()).build();
         DownloadConditions conditions = new DownloadConditions.Builder().build();
-        modelManager.download(model, conditions).addOnSuccessListener(unused -> callback.success()).addOnFailureListener(callback::error);
+        modelManager
+            .download(model, conditions)
+            .addOnSuccessListener(unused -> callback.success())
+            .addOnFailureListener(callback::error);
     }
 
     public void extractEntities(@NonNull ExtractEntitiesOptions options, @NonNull NonEmptyResultCallback<ExtractEntitiesResult> callback) {

--- a/packages/entity-extraction/package.json
+++ b/packages/entity-extraction/package.json
@@ -57,15 +57,15 @@
   },
   "devDependencies": {
     "@capacitor/android": "8.0.0",
-    "@capacitor/cli": "8.0.0",
+    "@capacitor/cli": "8.4.2",
     "@capacitor/core": "8.0.0",
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier-plugin-java": "2.6.7",
+    "prettier-plugin-java": "2.9.7",
     "rimraf": "6.1.2",
-    "rollup": "4.53.3",
+    "rollup": "4.62.3",
     "swiftlint": "2.0.0",
     "typescript": "5.9.3"
   },

--- a/packages/face-detection/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/facedetection/FaceDetection.java
+++ b/packages/face-detection/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/facedetection/FaceDetection.java
@@ -48,24 +48,22 @@ public class FaceDetection {
         FaceDetectorOptions faceDetectorOptions = builder.build();
 
         final FaceDetector faceDetector = com.google.mlkit.vision.face.FaceDetection.getClient(faceDetectorOptions);
-        plugin
-            .getActivity()
-            .runOnUiThread(() -> {
-                faceDetector
-                    .process(inputImage)
-                    .addOnSuccessListener(faces -> {
-                        faceDetector.close();
-                        ProcessImageResult result = new ProcessImageResult(faces);
-                        callback.success(result);
-                    })
-                    .addOnCanceledListener(() -> {
-                        faceDetector.close();
-                        callback.cancel();
-                    })
-                    .addOnFailureListener(exception -> {
-                        faceDetector.close();
-                        callback.error(exception);
-                    });
-            });
+        plugin.getActivity().runOnUiThread(() -> {
+            faceDetector
+                .process(inputImage)
+                .addOnSuccessListener(faces -> {
+                    faceDetector.close();
+                    ProcessImageResult result = new ProcessImageResult(faces);
+                    callback.success(result);
+                })
+                .addOnCanceledListener(() -> {
+                    faceDetector.close();
+                    callback.cancel();
+                })
+                .addOnFailureListener(exception -> {
+                    faceDetector.close();
+                    callback.error(exception);
+                });
+        });
     }
 }

--- a/packages/face-detection/package.json
+++ b/packages/face-detection/package.json
@@ -65,15 +65,15 @@
   },
   "devDependencies": {
     "@capacitor/android": "8.0.0",
-    "@capacitor/cli": "8.0.0",
+    "@capacitor/cli": "8.4.2",
     "@capacitor/core": "8.0.0",
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier-plugin-java": "2.6.7",
+    "prettier-plugin-java": "2.9.7",
     "rimraf": "6.1.2",
-    "rollup": "4.53.3",
+    "rollup": "4.62.3",
     "swiftlint": "2.0.0",
     "typescript": "5.9.3"
   },

--- a/packages/face-mesh-detection/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/facemeshdetection/FaceMeshDetection.java
+++ b/packages/face-mesh-detection/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/facemeshdetection/FaceMeshDetection.java
@@ -37,24 +37,22 @@ public class FaceMeshDetection {
         FaceMeshDetectorOptions faceMeshDetectorOptions = builder.build();
 
         final FaceMeshDetector faceMeshDetector = com.google.mlkit.vision.facemesh.FaceMeshDetection.getClient(faceMeshDetectorOptions);
-        plugin
-            .getActivity()
-            .runOnUiThread(() -> {
-                faceMeshDetector
-                    .process(inputImage)
-                    .addOnSuccessListener(faceMeshs -> {
-                        faceMeshDetector.close();
-                        ProcessImageResult result = new ProcessImageResult(faceMeshs);
-                        callback.success(result);
-                    })
-                    .addOnCanceledListener(() -> {
-                        faceMeshDetector.close();
-                        callback.cancel();
-                    })
-                    .addOnFailureListener(exception -> {
-                        faceMeshDetector.close();
-                        callback.error(exception);
-                    });
-            });
+        plugin.getActivity().runOnUiThread(() -> {
+            faceMeshDetector
+                .process(inputImage)
+                .addOnSuccessListener(faceMeshs -> {
+                    faceMeshDetector.close();
+                    ProcessImageResult result = new ProcessImageResult(faceMeshs);
+                    callback.success(result);
+                })
+                .addOnCanceledListener(() -> {
+                    faceMeshDetector.close();
+                    callback.cancel();
+                })
+                .addOnFailureListener(exception -> {
+                    faceMeshDetector.close();
+                    callback.error(exception);
+                });
+        });
     }
 }

--- a/packages/face-mesh-detection/package.json
+++ b/packages/face-mesh-detection/package.json
@@ -65,15 +65,15 @@
   },
   "devDependencies": {
     "@capacitor/android": "8.0.0",
-    "@capacitor/cli": "8.0.0",
+    "@capacitor/cli": "8.4.2",
     "@capacitor/core": "8.0.0",
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier-plugin-java": "2.6.7",
+    "prettier-plugin-java": "2.9.7",
     "rimraf": "6.1.2",
-    "rollup": "4.53.3",
+    "rollup": "4.62.3",
     "swiftlint": "2.0.0",
     "typescript": "5.9.3"
   },

--- a/packages/genai-image-description/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/genaiimagedescription/GenAiImageDescription.java
+++ b/packages/genai-image-description/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/genaiimagedescription/GenAiImageDescription.java
@@ -46,17 +46,14 @@ public class GenAiImageDescription {
     public void checkFeatureStatus(@NonNull NonEmptyResultCallback<CheckFeatureStatusResult> callback) {
         ImageDescriber imageDescriber = getImageDescriber();
         ListenableFuture<Integer> future = imageDescriber.checkFeatureStatus();
-        future.addListener(
-            () -> {
-                try {
-                    int featureStatus = future.get();
-                    callback.success(new CheckFeatureStatusResult(featureStatus));
-                } catch (Exception exception) {
-                    callback.error(unwrapException(exception));
-                }
-            },
-            executor
-        );
+        future.addListener(() -> {
+            try {
+                int featureStatus = future.get();
+                callback.success(new CheckFeatureStatusResult(featureStatus));
+            } catch (Exception exception) {
+                callback.error(unwrapException(exception));
+            }
+        }, executor);
     }
 
     public void describeImage(@NonNull DescribeImageOptions options, @NonNull NonEmptyResultCallback<DescribeImageResult> callback) {
@@ -72,57 +69,51 @@ public class GenAiImageDescription {
         ListenableFuture<ImageDescriptionResult> future = imageDescriber.runInference(request, additionalText ->
             plugin.notifyInferenceProgressListeners(new InferenceProgressEvent(additionalText))
         );
-        future.addListener(
-            () -> {
-                try {
-                    ImageDescriptionResult result = future.get();
-                    callback.success(new DescribeImageResult(result.getDescription()));
-                } catch (Exception exception) {
-                    callback.error(unwrapException(exception));
-                }
-            },
-            executor
-        );
+        future.addListener(() -> {
+            try {
+                ImageDescriptionResult result = future.get();
+                callback.success(new DescribeImageResult(result.getDescription()));
+            } catch (Exception exception) {
+                callback.error(unwrapException(exception));
+            }
+        }, executor);
     }
 
     public void downloadFeature(@NonNull EmptyCallback callback) {
         ImageDescriber imageDescriber = getImageDescriber();
         ListenableFuture<Integer> future = imageDescriber.checkFeatureStatus();
-        future.addListener(
-            () -> {
-                try {
-                    int featureStatus = future.get();
-                    if (featureStatus == FeatureStatus.AVAILABLE) {
-                        callback.success();
-                        return;
-                    }
-                    imageDescriber.downloadFeature(
-                        new DownloadCallback() {
-                            @Override
-                            public void onDownloadStarted(long bytesToDownload) {}
-
-                            @Override
-                            public void onDownloadProgress(long totalBytesDownloaded) {
-                                plugin.notifyDownloadProgressListeners(new DownloadProgressEvent(totalBytesDownloaded));
-                            }
-
-                            @Override
-                            public void onDownloadCompleted() {
-                                callback.success();
-                            }
-
-                            @Override
-                            public void onDownloadFailed(@NonNull GenAiException exception) {
-                                callback.error(exception);
-                            }
-                        }
-                    );
-                } catch (Exception exception) {
-                    callback.error(unwrapException(exception));
+        future.addListener(() -> {
+            try {
+                int featureStatus = future.get();
+                if (featureStatus == FeatureStatus.AVAILABLE) {
+                    callback.success();
+                    return;
                 }
-            },
-            executor
-        );
+                imageDescriber.downloadFeature(
+                    new DownloadCallback() {
+                        @Override
+                        public void onDownloadStarted(long bytesToDownload) {}
+
+                        @Override
+                        public void onDownloadProgress(long totalBytesDownloaded) {
+                            plugin.notifyDownloadProgressListeners(new DownloadProgressEvent(totalBytesDownloaded));
+                        }
+
+                        @Override
+                        public void onDownloadCompleted() {
+                            callback.success();
+                        }
+
+                        @Override
+                        public void onDownloadFailed(@NonNull GenAiException exception) {
+                            callback.error(exception);
+                        }
+                    }
+                );
+            } catch (Exception exception) {
+                callback.error(unwrapException(exception));
+            }
+        }, executor);
     }
 
     public void handleOnDestroy() {

--- a/packages/genai-image-description/package.json
+++ b/packages/genai-image-description/package.json
@@ -65,15 +65,15 @@
   },
   "devDependencies": {
     "@capacitor/android": "8.0.0",
-    "@capacitor/cli": "8.0.0",
+    "@capacitor/cli": "8.4.2",
     "@capacitor/core": "8.0.0",
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier-plugin-java": "2.6.7",
+    "prettier-plugin-java": "2.9.7",
     "rimraf": "6.1.2",
-    "rollup": "4.53.3",
+    "rollup": "4.62.3",
     "swiftlint": "2.0.0",
     "typescript": "5.9.3"
   },

--- a/packages/genai-prompt/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/genaiprompt/GenAiPrompt.java
+++ b/packages/genai-prompt/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/genaiprompt/GenAiPrompt.java
@@ -47,57 +47,51 @@ public class GenAiPrompt {
     public void checkFeatureStatus(@NonNull NonEmptyResultCallback<CheckFeatureStatusResult> callback) {
         GenerativeModelFutures generativeModel = getGenerativeModel();
         ListenableFuture<Integer> future = generativeModel.checkStatus();
-        future.addListener(
-            () -> {
-                try {
-                    int featureStatus = future.get();
-                    callback.success(new CheckFeatureStatusResult(featureStatus));
-                } catch (Exception exception) {
-                    callback.error(unwrapException(exception));
-                }
-            },
-            executor
-        );
+        future.addListener(() -> {
+            try {
+                int featureStatus = future.get();
+                callback.success(new CheckFeatureStatusResult(featureStatus));
+            } catch (Exception exception) {
+                callback.error(unwrapException(exception));
+            }
+        }, executor);
     }
 
     public void downloadFeature(@NonNull EmptyCallback callback) {
         GenerativeModelFutures generativeModel = getGenerativeModel();
         ListenableFuture<Integer> future = generativeModel.checkStatus();
-        future.addListener(
-            () -> {
-                try {
-                    int featureStatus = future.get();
-                    if (featureStatus == FeatureStatus.AVAILABLE) {
-                        callback.success();
-                        return;
-                    }
-                    generativeModel.download(
-                        new DownloadCallback() {
-                            @Override
-                            public void onDownloadStarted(long bytesToDownload) {}
-
-                            @Override
-                            public void onDownloadProgress(long totalBytesDownloaded) {
-                                plugin.notifyDownloadProgressListeners(new DownloadProgressEvent(totalBytesDownloaded));
-                            }
-
-                            @Override
-                            public void onDownloadCompleted() {
-                                callback.success();
-                            }
-
-                            @Override
-                            public void onDownloadFailed(@NonNull GenAiException exception) {
-                                callback.error(exception);
-                            }
-                        }
-                    );
-                } catch (Exception exception) {
-                    callback.error(unwrapException(exception));
+        future.addListener(() -> {
+            try {
+                int featureStatus = future.get();
+                if (featureStatus == FeatureStatus.AVAILABLE) {
+                    callback.success();
+                    return;
                 }
-            },
-            executor
-        );
+                generativeModel.download(
+                    new DownloadCallback() {
+                        @Override
+                        public void onDownloadStarted(long bytesToDownload) {}
+
+                        @Override
+                        public void onDownloadProgress(long totalBytesDownloaded) {
+                            plugin.notifyDownloadProgressListeners(new DownloadProgressEvent(totalBytesDownloaded));
+                        }
+
+                        @Override
+                        public void onDownloadCompleted() {
+                            callback.success();
+                        }
+
+                        @Override
+                        public void onDownloadFailed(@NonNull GenAiException exception) {
+                            callback.error(exception);
+                        }
+                    }
+                );
+            } catch (Exception exception) {
+                callback.error(unwrapException(exception));
+            }
+        }, executor);
     }
 
     public void generateContent(@NonNull GenerateContentOptions options, @NonNull NonEmptyResultCallback<GenerateContentResult> callback) {
@@ -125,17 +119,14 @@ public class GenAiPrompt {
         ListenableFuture<GenerateContentResponse> future = generativeModel.generateContent(requestBuilder.build(), additionalText ->
             plugin.notifyInferenceProgressListeners(new InferenceProgressEvent(additionalText))
         );
-        future.addListener(
-            () -> {
-                try {
-                    GenerateContentResponse response = future.get();
-                    callback.success(new GenerateContentResult(response.getCandidates().get(0).getText()));
-                } catch (Exception exception) {
-                    callback.error(unwrapException(exception));
-                }
-            },
-            executor
-        );
+        future.addListener(() -> {
+            try {
+                GenerateContentResponse response = future.get();
+                callback.success(new GenerateContentResult(response.getCandidates().get(0).getText()));
+            } catch (Exception exception) {
+                callback.error(unwrapException(exception));
+            }
+        }, executor);
     }
 
     public void handleOnDestroy() {

--- a/packages/genai-prompt/package.json
+++ b/packages/genai-prompt/package.json
@@ -65,15 +65,15 @@
   },
   "devDependencies": {
     "@capacitor/android": "8.0.0",
-    "@capacitor/cli": "8.0.0",
+    "@capacitor/cli": "8.4.2",
     "@capacitor/core": "8.0.0",
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier-plugin-java": "2.6.7",
+    "prettier-plugin-java": "2.9.7",
     "rimraf": "6.1.2",
-    "rollup": "4.53.3",
+    "rollup": "4.62.3",
     "swiftlint": "2.0.0",
     "typescript": "5.9.3"
   },

--- a/packages/genai-proofreading/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/genaiproofreading/GenAiProofreading.java
+++ b/packages/genai-proofreading/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/genaiproofreading/GenAiProofreading.java
@@ -47,57 +47,51 @@ public class GenAiProofreading {
     public void checkFeatureStatus(@NonNull FeatureOptions options, @NonNull NonEmptyResultCallback<CheckFeatureStatusResult> callback) {
         Proofreader proofreader = getProofreader(options);
         ListenableFuture<Integer> future = proofreader.checkFeatureStatus();
-        future.addListener(
-            () -> {
-                try {
-                    int featureStatus = future.get();
-                    callback.success(new CheckFeatureStatusResult(featureStatus));
-                } catch (Exception exception) {
-                    callback.error(unwrapException(exception));
-                }
-            },
-            executor
-        );
+        future.addListener(() -> {
+            try {
+                int featureStatus = future.get();
+                callback.success(new CheckFeatureStatusResult(featureStatus));
+            } catch (Exception exception) {
+                callback.error(unwrapException(exception));
+            }
+        }, executor);
     }
 
     public void downloadFeature(@NonNull FeatureOptions options, @NonNull EmptyCallback callback) {
         Proofreader proofreader = getProofreader(options);
         ListenableFuture<Integer> future = proofreader.checkFeatureStatus();
-        future.addListener(
-            () -> {
-                try {
-                    int featureStatus = future.get();
-                    if (featureStatus == FeatureStatus.AVAILABLE) {
-                        callback.success();
-                        return;
-                    }
-                    proofreader.downloadFeature(
-                        new DownloadCallback() {
-                            @Override
-                            public void onDownloadStarted(long bytesToDownload) {}
-
-                            @Override
-                            public void onDownloadProgress(long totalBytesDownloaded) {
-                                plugin.notifyDownloadProgressListeners(new DownloadProgressEvent(totalBytesDownloaded));
-                            }
-
-                            @Override
-                            public void onDownloadCompleted() {
-                                callback.success();
-                            }
-
-                            @Override
-                            public void onDownloadFailed(@NonNull GenAiException exception) {
-                                callback.error(exception);
-                            }
-                        }
-                    );
-                } catch (Exception exception) {
-                    callback.error(unwrapException(exception));
+        future.addListener(() -> {
+            try {
+                int featureStatus = future.get();
+                if (featureStatus == FeatureStatus.AVAILABLE) {
+                    callback.success();
+                    return;
                 }
-            },
-            executor
-        );
+                proofreader.downloadFeature(
+                    new DownloadCallback() {
+                        @Override
+                        public void onDownloadStarted(long bytesToDownload) {}
+
+                        @Override
+                        public void onDownloadProgress(long totalBytesDownloaded) {
+                            plugin.notifyDownloadProgressListeners(new DownloadProgressEvent(totalBytesDownloaded));
+                        }
+
+                        @Override
+                        public void onDownloadCompleted() {
+                            callback.success();
+                        }
+
+                        @Override
+                        public void onDownloadFailed(@NonNull GenAiException exception) {
+                            callback.error(exception);
+                        }
+                    }
+                );
+            } catch (Exception exception) {
+                callback.error(unwrapException(exception));
+            }
+        }, executor);
     }
 
     public void handleOnDestroy() {
@@ -110,21 +104,18 @@ public class GenAiProofreading {
         ListenableFuture<ProofreadingResult> future = proofreader.runInference(request, additionalText ->
             plugin.notifyInferenceProgressListeners(new InferenceProgressEvent(additionalText))
         );
-        future.addListener(
-            () -> {
-                try {
-                    ProofreadingResult result = future.get();
-                    List<String> results = new ArrayList<>();
-                    for (ProofreadingSuggestion suggestion : result.getResults()) {
-                        results.add(suggestion.getText());
-                    }
-                    callback.success(new ProofreadResult(results));
-                } catch (Exception exception) {
-                    callback.error(unwrapException(exception));
+        future.addListener(() -> {
+            try {
+                ProofreadingResult result = future.get();
+                List<String> results = new ArrayList<>();
+                for (ProofreadingSuggestion suggestion : result.getResults()) {
+                    results.add(suggestion.getText());
                 }
-            },
-            executor
-        );
+                callback.success(new ProofreadResult(results));
+            } catch (Exception exception) {
+                callback.error(unwrapException(exception));
+            }
+        }, executor);
     }
 
     private void closeProofreader() {

--- a/packages/genai-proofreading/package.json
+++ b/packages/genai-proofreading/package.json
@@ -65,15 +65,15 @@
   },
   "devDependencies": {
     "@capacitor/android": "8.0.0",
-    "@capacitor/cli": "8.0.0",
+    "@capacitor/cli": "8.4.2",
     "@capacitor/core": "8.0.0",
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier-plugin-java": "2.6.7",
+    "prettier-plugin-java": "2.9.7",
     "rimraf": "6.1.2",
-    "rollup": "4.53.3",
+    "rollup": "4.62.3",
     "swiftlint": "2.0.0",
     "typescript": "5.9.3"
   },

--- a/packages/genai-rewriting/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/genairewriting/GenAiRewriting.java
+++ b/packages/genai-rewriting/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/genairewriting/GenAiRewriting.java
@@ -47,57 +47,51 @@ public class GenAiRewriting {
     public void checkFeatureStatus(@NonNull FeatureOptions options, @NonNull NonEmptyResultCallback<CheckFeatureStatusResult> callback) {
         Rewriter rewriter = getRewriter(options);
         ListenableFuture<Integer> future = rewriter.checkFeatureStatus();
-        future.addListener(
-            () -> {
-                try {
-                    int featureStatus = future.get();
-                    callback.success(new CheckFeatureStatusResult(featureStatus));
-                } catch (Exception exception) {
-                    callback.error(unwrapException(exception));
-                }
-            },
-            executor
-        );
+        future.addListener(() -> {
+            try {
+                int featureStatus = future.get();
+                callback.success(new CheckFeatureStatusResult(featureStatus));
+            } catch (Exception exception) {
+                callback.error(unwrapException(exception));
+            }
+        }, executor);
     }
 
     public void downloadFeature(@NonNull FeatureOptions options, @NonNull EmptyCallback callback) {
         Rewriter rewriter = getRewriter(options);
         ListenableFuture<Integer> future = rewriter.checkFeatureStatus();
-        future.addListener(
-            () -> {
-                try {
-                    int featureStatus = future.get();
-                    if (featureStatus == FeatureStatus.AVAILABLE) {
-                        callback.success();
-                        return;
-                    }
-                    rewriter.downloadFeature(
-                        new DownloadCallback() {
-                            @Override
-                            public void onDownloadStarted(long bytesToDownload) {}
-
-                            @Override
-                            public void onDownloadProgress(long totalBytesDownloaded) {
-                                plugin.notifyDownloadProgressListeners(new DownloadProgressEvent(totalBytesDownloaded));
-                            }
-
-                            @Override
-                            public void onDownloadCompleted() {
-                                callback.success();
-                            }
-
-                            @Override
-                            public void onDownloadFailed(@NonNull GenAiException exception) {
-                                callback.error(exception);
-                            }
-                        }
-                    );
-                } catch (Exception exception) {
-                    callback.error(unwrapException(exception));
+        future.addListener(() -> {
+            try {
+                int featureStatus = future.get();
+                if (featureStatus == FeatureStatus.AVAILABLE) {
+                    callback.success();
+                    return;
                 }
-            },
-            executor
-        );
+                rewriter.downloadFeature(
+                    new DownloadCallback() {
+                        @Override
+                        public void onDownloadStarted(long bytesToDownload) {}
+
+                        @Override
+                        public void onDownloadProgress(long totalBytesDownloaded) {
+                            plugin.notifyDownloadProgressListeners(new DownloadProgressEvent(totalBytesDownloaded));
+                        }
+
+                        @Override
+                        public void onDownloadCompleted() {
+                            callback.success();
+                        }
+
+                        @Override
+                        public void onDownloadFailed(@NonNull GenAiException exception) {
+                            callback.error(exception);
+                        }
+                    }
+                );
+            } catch (Exception exception) {
+                callback.error(unwrapException(exception));
+            }
+        }, executor);
     }
 
     public void handleOnDestroy() {
@@ -110,21 +104,18 @@ public class GenAiRewriting {
         ListenableFuture<RewritingResult> future = rewriter.runInference(request, additionalText ->
             plugin.notifyInferenceProgressListeners(new InferenceProgressEvent(additionalText))
         );
-        future.addListener(
-            () -> {
-                try {
-                    RewritingResult result = future.get();
-                    List<String> results = new ArrayList<>();
-                    for (RewritingSuggestion suggestion : result.getResults()) {
-                        results.add(suggestion.getText());
-                    }
-                    callback.success(new RewriteResult(results));
-                } catch (Exception exception) {
-                    callback.error(unwrapException(exception));
+        future.addListener(() -> {
+            try {
+                RewritingResult result = future.get();
+                List<String> results = new ArrayList<>();
+                for (RewritingSuggestion suggestion : result.getResults()) {
+                    results.add(suggestion.getText());
                 }
-            },
-            executor
-        );
+                callback.success(new RewriteResult(results));
+            } catch (Exception exception) {
+                callback.error(unwrapException(exception));
+            }
+        }, executor);
     }
 
     private void closeRewriter() {

--- a/packages/genai-rewriting/package.json
+++ b/packages/genai-rewriting/package.json
@@ -65,15 +65,15 @@
   },
   "devDependencies": {
     "@capacitor/android": "8.0.0",
-    "@capacitor/cli": "8.0.0",
+    "@capacitor/cli": "8.4.2",
     "@capacitor/core": "8.0.0",
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier-plugin-java": "2.6.7",
+    "prettier-plugin-java": "2.9.7",
     "rimraf": "6.1.2",
-    "rollup": "4.53.3",
+    "rollup": "4.62.3",
     "swiftlint": "2.0.0",
     "typescript": "5.9.3"
   },

--- a/packages/genai-speech-recognition/package.json
+++ b/packages/genai-speech-recognition/package.json
@@ -66,15 +66,15 @@
   },
   "devDependencies": {
     "@capacitor/android": "8.0.0",
-    "@capacitor/cli": "8.0.0",
+    "@capacitor/cli": "8.4.2",
     "@capacitor/core": "8.0.0",
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier-plugin-java": "2.6.7",
+    "prettier-plugin-java": "2.9.7",
     "rimraf": "6.1.2",
-    "rollup": "4.53.3",
+    "rollup": "4.62.3",
     "swiftlint": "2.0.0",
     "typescript": "5.9.3"
   },

--- a/packages/genai-summarization/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/genaisummarization/GenAiSummarization.java
+++ b/packages/genai-summarization/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/genaisummarization/GenAiSummarization.java
@@ -44,57 +44,51 @@ public class GenAiSummarization {
     public void checkFeatureStatus(@NonNull FeatureOptions options, @NonNull NonEmptyResultCallback<CheckFeatureStatusResult> callback) {
         Summarizer summarizer = getSummarizer(options);
         ListenableFuture<Integer> future = summarizer.checkFeatureStatus();
-        future.addListener(
-            () -> {
-                try {
-                    int featureStatus = future.get();
-                    callback.success(new CheckFeatureStatusResult(featureStatus));
-                } catch (Exception exception) {
-                    callback.error(unwrapException(exception));
-                }
-            },
-            executor
-        );
+        future.addListener(() -> {
+            try {
+                int featureStatus = future.get();
+                callback.success(new CheckFeatureStatusResult(featureStatus));
+            } catch (Exception exception) {
+                callback.error(unwrapException(exception));
+            }
+        }, executor);
     }
 
     public void downloadFeature(@NonNull FeatureOptions options, @NonNull EmptyCallback callback) {
         Summarizer summarizer = getSummarizer(options);
         ListenableFuture<Integer> future = summarizer.checkFeatureStatus();
-        future.addListener(
-            () -> {
-                try {
-                    int featureStatus = future.get();
-                    if (featureStatus == FeatureStatus.AVAILABLE) {
-                        callback.success();
-                        return;
-                    }
-                    summarizer.downloadFeature(
-                        new DownloadCallback() {
-                            @Override
-                            public void onDownloadStarted(long bytesToDownload) {}
-
-                            @Override
-                            public void onDownloadProgress(long totalBytesDownloaded) {
-                                plugin.notifyDownloadProgressListeners(new DownloadProgressEvent(totalBytesDownloaded));
-                            }
-
-                            @Override
-                            public void onDownloadCompleted() {
-                                callback.success();
-                            }
-
-                            @Override
-                            public void onDownloadFailed(@NonNull GenAiException exception) {
-                                callback.error(exception);
-                            }
-                        }
-                    );
-                } catch (Exception exception) {
-                    callback.error(unwrapException(exception));
+        future.addListener(() -> {
+            try {
+                int featureStatus = future.get();
+                if (featureStatus == FeatureStatus.AVAILABLE) {
+                    callback.success();
+                    return;
                 }
-            },
-            executor
-        );
+                summarizer.downloadFeature(
+                    new DownloadCallback() {
+                        @Override
+                        public void onDownloadStarted(long bytesToDownload) {}
+
+                        @Override
+                        public void onDownloadProgress(long totalBytesDownloaded) {
+                            plugin.notifyDownloadProgressListeners(new DownloadProgressEvent(totalBytesDownloaded));
+                        }
+
+                        @Override
+                        public void onDownloadCompleted() {
+                            callback.success();
+                        }
+
+                        @Override
+                        public void onDownloadFailed(@NonNull GenAiException exception) {
+                            callback.error(exception);
+                        }
+                    }
+                );
+            } catch (Exception exception) {
+                callback.error(unwrapException(exception));
+            }
+        }, executor);
     }
 
     public void handleOnDestroy() {
@@ -107,17 +101,14 @@ public class GenAiSummarization {
         ListenableFuture<SummarizationResult> future = summarizer.runInference(request, additionalText ->
             plugin.notifyInferenceProgressListeners(new InferenceProgressEvent(additionalText))
         );
-        future.addListener(
-            () -> {
-                try {
-                    SummarizationResult result = future.get();
-                    callback.success(new SummarizeResult(result.getSummary()));
-                } catch (Exception exception) {
-                    callback.error(unwrapException(exception));
-                }
-            },
-            executor
-        );
+        future.addListener(() -> {
+            try {
+                SummarizationResult result = future.get();
+                callback.success(new SummarizeResult(result.getSummary()));
+            } catch (Exception exception) {
+                callback.error(unwrapException(exception));
+            }
+        }, executor);
     }
 
     private void closeSummarizer() {

--- a/packages/genai-summarization/package.json
+++ b/packages/genai-summarization/package.json
@@ -65,15 +65,15 @@
   },
   "devDependencies": {
     "@capacitor/android": "8.0.0",
-    "@capacitor/cli": "8.0.0",
+    "@capacitor/cli": "8.4.2",
     "@capacitor/core": "8.0.0",
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier-plugin-java": "2.6.7",
+    "prettier-plugin-java": "2.9.7",
     "rimraf": "6.1.2",
-    "rollup": "4.53.3",
+    "rollup": "4.62.3",
     "swiftlint": "2.0.0",
     "typescript": "5.9.3"
   },

--- a/packages/image-labeling/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/imagelabeling/ImageLabeling.java
+++ b/packages/image-labeling/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/imagelabeling/ImageLabeling.java
@@ -30,25 +30,23 @@ public class ImageLabeling {
         ImageLabelerOptions imageLabelerOptions = new ImageLabelerOptions.Builder().setConfidenceThreshold(confidenceThreshold).build();
 
         final ImageLabeler imageLabeler = com.google.mlkit.vision.label.ImageLabeling.getClient(imageLabelerOptions);
-        plugin
-            .getActivity()
-            .runOnUiThread(() -> {
-                imageLabeler
-                    .process(inputImage)
-                    .addOnSuccessListener(labels -> {
-                        imageLabeler.close();
-                        ProcessImageResult result = new ProcessImageResult(labels);
-                        callback.success(result);
-                    })
-                    .addOnCanceledListener(() -> {
-                        imageLabeler.close();
-                        callback.error(new Exception(ImageLabelingPlugin.ERROR_PROCESS_IMAGE_CANCELED));
-                    })
-                    .addOnFailureListener(exception -> {
-                        imageLabeler.close();
-                        callback.error(exception);
-                    });
-            });
+        plugin.getActivity().runOnUiThread(() -> {
+            imageLabeler
+                .process(inputImage)
+                .addOnSuccessListener(labels -> {
+                    imageLabeler.close();
+                    ProcessImageResult result = new ProcessImageResult(labels);
+                    callback.success(result);
+                })
+                .addOnCanceledListener(() -> {
+                    imageLabeler.close();
+                    callback.error(new Exception(ImageLabelingPlugin.ERROR_PROCESS_IMAGE_CANCELED));
+                })
+                .addOnFailureListener(exception -> {
+                    imageLabeler.close();
+                    callback.error(exception);
+                });
+        });
     }
 
     @Nullable

--- a/packages/image-labeling/package.json
+++ b/packages/image-labeling/package.json
@@ -61,15 +61,15 @@
   },
   "devDependencies": {
     "@capacitor/android": "8.0.0",
-    "@capacitor/cli": "8.0.0",
+    "@capacitor/cli": "8.4.2",
     "@capacitor/core": "8.0.0",
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier-plugin-java": "2.6.7",
+    "prettier-plugin-java": "2.9.7",
     "rimraf": "6.1.2",
-    "rollup": "4.53.3",
+    "rollup": "4.62.3",
     "swiftlint": "2.0.0",
     "typescript": "5.9.3"
   },

--- a/packages/language-identification/package.json
+++ b/packages/language-identification/package.json
@@ -57,15 +57,15 @@
   },
   "devDependencies": {
     "@capacitor/android": "8.0.0",
-    "@capacitor/cli": "8.0.0",
+    "@capacitor/cli": "8.4.2",
     "@capacitor/core": "8.0.0",
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier-plugin-java": "2.6.7",
+    "prettier-plugin-java": "2.9.7",
     "rimraf": "6.1.2",
-    "rollup": "4.53.3",
+    "rollup": "4.62.3",
     "swiftlint": "2.0.0",
     "typescript": "5.9.3"
   },

--- a/packages/object-detection/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/objectdetection/ObjectDetection.java
+++ b/packages/object-detection/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/objectdetection/ObjectDetection.java
@@ -26,8 +26,9 @@ public class ObjectDetection {
             return;
         }
 
-        ObjectDetectorOptions.Builder optionsBuilder = new ObjectDetectorOptions.Builder()
-            .setDetectorMode(ObjectDetectorOptions.SINGLE_IMAGE_MODE);
+        ObjectDetectorOptions.Builder optionsBuilder = new ObjectDetectorOptions.Builder().setDetectorMode(
+            ObjectDetectorOptions.SINGLE_IMAGE_MODE
+        );
         if (options.isClassificationEnabled()) {
             optionsBuilder.enableClassification();
         }
@@ -36,25 +37,23 @@ public class ObjectDetection {
         }
 
         final ObjectDetector objectDetector = com.google.mlkit.vision.objects.ObjectDetection.getClient(optionsBuilder.build());
-        plugin
-            .getActivity()
-            .runOnUiThread(() -> {
-                objectDetector
-                    .process(inputImage)
-                    .addOnSuccessListener(detectedObjects -> {
-                        objectDetector.close();
-                        ProcessImageResult result = new ProcessImageResult(detectedObjects);
-                        callback.success(result);
-                    })
-                    .addOnCanceledListener(() -> {
-                        objectDetector.close();
-                        callback.error(new Exception(ObjectDetectionPlugin.ERROR_PROCESS_IMAGE_CANCELED));
-                    })
-                    .addOnFailureListener(exception -> {
-                        objectDetector.close();
-                        callback.error(exception);
-                    });
-            });
+        plugin.getActivity().runOnUiThread(() -> {
+            objectDetector
+                .process(inputImage)
+                .addOnSuccessListener(detectedObjects -> {
+                    objectDetector.close();
+                    ProcessImageResult result = new ProcessImageResult(detectedObjects);
+                    callback.success(result);
+                })
+                .addOnCanceledListener(() -> {
+                    objectDetector.close();
+                    callback.error(new Exception(ObjectDetectionPlugin.ERROR_PROCESS_IMAGE_CANCELED));
+                })
+                .addOnFailureListener(exception -> {
+                    objectDetector.close();
+                    callback.error(exception);
+                });
+        });
     }
 
     @Nullable

--- a/packages/object-detection/package.json
+++ b/packages/object-detection/package.json
@@ -60,15 +60,15 @@
   },
   "devDependencies": {
     "@capacitor/android": "8.0.0",
-    "@capacitor/cli": "8.0.0",
+    "@capacitor/cli": "8.4.2",
     "@capacitor/core": "8.0.0",
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier-plugin-java": "2.6.7",
+    "prettier-plugin-java": "2.9.7",
     "rimraf": "6.1.2",
-    "rollup": "4.53.3",
+    "rollup": "4.62.3",
     "swiftlint": "2.0.0",
     "typescript": "5.9.3"
   },

--- a/packages/pose-detection/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/posedetection/PoseDetection.java
+++ b/packages/pose-detection/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/posedetection/PoseDetection.java
@@ -38,25 +38,23 @@ public class PoseDetection {
         }
 
         final PoseDetector poseDetector = com.google.mlkit.vision.pose.PoseDetection.getClient(poseDetectorOptions);
-        plugin
-            .getActivity()
-            .runOnUiThread(() -> {
-                poseDetector
-                    .process(inputImage)
-                    .addOnSuccessListener(pose -> {
-                        poseDetector.close();
-                        ProcessImageResult result = new ProcessImageResult(pose);
-                        callback.success(result);
-                    })
-                    .addOnCanceledListener(() -> {
-                        poseDetector.close();
-                        callback.error(new Exception(PoseDetectionPlugin.ERROR_PROCESS_IMAGE_CANCELED));
-                    })
-                    .addOnFailureListener(exception -> {
-                        poseDetector.close();
-                        callback.error(exception);
-                    });
-            });
+        plugin.getActivity().runOnUiThread(() -> {
+            poseDetector
+                .process(inputImage)
+                .addOnSuccessListener(pose -> {
+                    poseDetector.close();
+                    ProcessImageResult result = new ProcessImageResult(pose);
+                    callback.success(result);
+                })
+                .addOnCanceledListener(() -> {
+                    poseDetector.close();
+                    callback.error(new Exception(PoseDetectionPlugin.ERROR_PROCESS_IMAGE_CANCELED));
+                })
+                .addOnFailureListener(exception -> {
+                    poseDetector.close();
+                    callback.error(exception);
+                });
+        });
     }
 
     @Nullable

--- a/packages/pose-detection/package.json
+++ b/packages/pose-detection/package.json
@@ -60,15 +60,15 @@
   },
   "devDependencies": {
     "@capacitor/android": "8.0.0",
-    "@capacitor/cli": "8.0.0",
+    "@capacitor/cli": "8.4.2",
     "@capacitor/core": "8.0.0",
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier-plugin-java": "2.6.7",
+    "prettier-plugin-java": "2.9.7",
     "rimraf": "6.1.2",
-    "rollup": "4.53.3",
+    "rollup": "4.62.3",
     "swiftlint": "2.0.0",
     "typescript": "5.9.3"
   },

--- a/packages/selfie-segmentation/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/selfiesegmentation/SelfieSegmentation.java
+++ b/packages/selfie-segmentation/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/selfiesegmentation/SelfieSegmentation.java
@@ -48,78 +48,72 @@ public class SelfieSegmentation {
 
         final Segmenter segmenter = Segmentation.getClient(selfieSegmenterOptions);
 
-        plugin
-            .getActivity()
-            .runOnUiThread(() ->
-                segmenter
-                    .process(inputImage)
-                    .addOnSuccessListener(segmentationMask -> {
-                        segmenter.close();
+        plugin.getActivity().runOnUiThread(() ->
+            segmenter
+                .process(inputImage)
+                .addOnSuccessListener(segmentationMask -> {
+                    segmenter.close();
 
-                        ByteBuffer mask = segmentationMask.getBuffer();
+                    ByteBuffer mask = segmentationMask.getBuffer();
 
-                        Bitmap bitmap = inputImage.getBitmapInternal();
-                        Objects.requireNonNull(bitmap).setHasAlpha(true);
+                    Bitmap bitmap = inputImage.getBitmapInternal();
+                    Objects.requireNonNull(bitmap).setHasAlpha(true);
 
-                        ByteBuffer pixels = ByteBuffer.allocateDirect(bitmap.getAllocationByteCount());
-                        bitmap.copyPixelsToBuffer(pixels);
+                    ByteBuffer pixels = ByteBuffer.allocateDirect(bitmap.getAllocationByteCount());
+                    bitmap.copyPixelsToBuffer(pixels);
 
-                        final boolean bigEndian = pixels.order() == ByteOrder.BIG_ENDIAN;
-                        final int ALPHA = bigEndian ? 3 : 0;
-                        final int RED = bigEndian ? 2 : 1;
-                        final int GREEN = bigEndian ? 1 : 2;
-                        final int BLUE = bigEndian ? 0 : 3;
+                    final boolean bigEndian = pixels.order() == ByteOrder.BIG_ENDIAN;
+                    final int ALPHA = bigEndian ? 3 : 0;
+                    final int RED = bigEndian ? 2 : 1;
+                    final int GREEN = bigEndian ? 1 : 2;
+                    final int BLUE = bigEndian ? 0 : 3;
 
-                        for (int i = 0; i < pixels.capacity() >> 2; i++) {
-                            float confidence = mask.getFloat();
+                    for (int i = 0; i < pixels.capacity() >> 2; i++) {
+                        float confidence = mask.getFloat();
 
-                            if (confidence >= threshold) {
-                                byte red = pixels.get((i << 2) + RED);
-                                byte green = pixels.get((i << 2) + GREEN);
-                                byte blue = pixels.get((i << 2) + BLUE);
+                        if (confidence >= threshold) {
+                            byte red = pixels.get((i << 2) + RED);
+                            byte green = pixels.get((i << 2) + GREEN);
+                            byte blue = pixels.get((i << 2) + BLUE);
 
-                                pixels.put((i << 2) + ALPHA, (byte) (0xff));
-                                pixels.put((i << 2) + RED, (byte) (red * confidence));
-                                pixels.put((i << 2) + GREEN, (byte) (green * confidence));
-                                pixels.put((i << 2) + BLUE, (byte) (blue * confidence));
-                            } else {
-                                pixels.putInt(i << 2, 0x00000000); // transparent
-                            }
+                            pixels.put((i << 2) + ALPHA, (byte) (0xff));
+                            pixels.put((i << 2) + RED, (byte) (red * confidence));
+                            pixels.put((i << 2) + GREEN, (byte) (green * confidence));
+                            pixels.put((i << 2) + BLUE, (byte) (blue * confidence));
+                        } else {
+                            pixels.putInt(i << 2, 0x00000000); // transparent
                         }
+                    }
 
-                        bitmap.copyPixelsFromBuffer(pixels.rewind());
+                    bitmap.copyPixelsFromBuffer(pixels.rewind());
 
-                        // Create an image file name
-                        @SuppressLint("SimpleDateFormat")
-                        String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
-                        String imageFileName = "PNG_" + timeStamp + "_";
+                    // Create an image file name
+                    @SuppressLint("SimpleDateFormat")
+                    String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
+                    String imageFileName = "PNG_" + timeStamp + "_";
 
-                        try {
-                            File image = File.createTempFile(imageFileName, ".png");
+                    try {
+                        File image = File.createTempFile(imageFileName, ".png");
 
-                            OutputStream stream = new FileOutputStream(image);
-                            bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream);
-                            stream.close();
+                        OutputStream stream = new FileOutputStream(image);
+                        bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream);
+                        stream.close();
 
-                            ProcessImageResult result = new ProcessImageResult(
-                                image.getAbsolutePath(),
-                                bitmap.getWidth(),
-                                bitmap.getHeight()
-                            );
+                        ProcessImageResult result = new ProcessImageResult(image.getAbsolutePath(), bitmap.getWidth(), bitmap.getHeight());
 
-                            callback.success(result);
-                        } catch (Exception exception) {
-                            callback.error(exception);
-                        }
-                    })
-                    .addOnCanceledListener(() -> {
-                        segmenter.close();
-                        callback.cancel();
-                    })
-                    .addOnFailureListener(exception -> {
-                        segmenter.close();
+                        callback.success(result);
+                    } catch (Exception exception) {
                         callback.error(exception);
-                    })
-            );
+                    }
+                })
+                .addOnCanceledListener(() -> {
+                    segmenter.close();
+                    callback.cancel();
+                })
+                .addOnFailureListener(exception -> {
+                    segmenter.close();
+                    callback.error(exception);
+                })
+        );
     }
 }

--- a/packages/selfie-segmentation/package.json
+++ b/packages/selfie-segmentation/package.json
@@ -66,15 +66,15 @@
   },
   "devDependencies": {
     "@capacitor/android": "8.0.0",
-    "@capacitor/cli": "8.0.0",
+    "@capacitor/cli": "8.4.2",
     "@capacitor/core": "8.0.0",
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier-plugin-java": "2.6.7",
+    "prettier-plugin-java": "2.9.7",
     "rimraf": "6.1.2",
-    "rollup": "4.53.3",
+    "rollup": "4.62.3",
     "swiftlint": "2.0.0",
     "typescript": "5.9.3"
   },

--- a/packages/smart-reply/package.json
+++ b/packages/smart-reply/package.json
@@ -65,15 +65,15 @@
   },
   "devDependencies": {
     "@capacitor/android": "8.0.0",
-    "@capacitor/cli": "8.0.0",
+    "@capacitor/cli": "8.4.2",
     "@capacitor/core": "8.0.0",
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier-plugin-java": "2.6.7",
+    "prettier-plugin-java": "2.9.7",
     "rimraf": "6.1.2",
-    "rollup": "4.53.3",
+    "rollup": "4.62.3",
     "swiftlint": "2.0.0",
     "typescript": "5.9.3"
   },

--- a/packages/subject-segmentation/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/subjectsegmentation/SubjectSegmentation.java
+++ b/packages/subject-segmentation/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/subjectsegmentation/SubjectSegmentation.java
@@ -69,87 +69,80 @@ public class SubjectSegmentation {
             subjectSegmenterOptions
         );
 
-        plugin
-            .getActivity()
-            .runOnUiThread(() ->
-                segmenter
-                    .process(inputImage)
-                    .addOnSuccessListener(segmentationResult -> {
-                        segmenter.close();
+        plugin.getActivity().runOnUiThread(() ->
+            segmenter
+                .process(inputImage)
+                .addOnSuccessListener(segmentationResult -> {
+                    segmenter.close();
 
-                        List<Subject> subjects = segmentationResult.getSubjects();
+                    List<Subject> subjects = segmentationResult.getSubjects();
 
-                        int[] colors = new int[inputImage.getWidth() * inputImage.getHeight()];
-                        for (Subject subject : subjects) {
-                            FloatBuffer mask = subject.getConfidenceMask();
-                            assert mask != null;
-                            for (int i = 0; i < subject.getWidth() * subject.getHeight(); i++) {
-                                float confidence = mask.get(i);
-                                if (confidence > threshold) {
-                                    int x = subject.getStartX() + (i % subject.getWidth());
-                                    int y = subject.getStartY() + (i / subject.getWidth());
-                                    int position = y * inputImage.getWidth() + x;
+                    int[] colors = new int[inputImage.getWidth() * inputImage.getHeight()];
+                    for (Subject subject : subjects) {
+                        FloatBuffer mask = subject.getConfidenceMask();
+                        assert mask != null;
+                        for (int i = 0; i < subject.getWidth() * subject.getHeight(); i++) {
+                            float confidence = mask.get(i);
+                            if (confidence > threshold) {
+                                int x = subject.getStartX() + (i % subject.getWidth());
+                                int y = subject.getStartY() + (i / subject.getWidth());
+                                int position = y * inputImage.getWidth() + x;
 
-                                    colors[position] = Color.argb(128, 255, 0, 255);
-                                }
+                                colors[position] = Color.argb(128, 255, 0, 255);
                             }
                         }
+                    }
 
-                        Bitmap maskBitmap = Bitmap.createBitmap(
-                            colors,
-                            inputImage.getWidth(),
-                            inputImage.getHeight(),
-                            Bitmap.Config.ARGB_8888
+                    Bitmap maskBitmap = Bitmap.createBitmap(colors, inputImage.getWidth(), inputImage.getHeight(), Bitmap.Config.ARGB_8888);
+
+                    Bitmap originalBitmap = Bitmap.createScaledBitmap(
+                        Objects.requireNonNull(inputImage.getBitmapInternal()),
+                        maskBitmap.getWidth(),
+                        maskBitmap.getHeight(),
+                        true
+                    );
+
+                    Bitmap resultBitmap = Bitmap.createBitmap(maskBitmap.getWidth(), maskBitmap.getHeight(), Bitmap.Config.ARGB_8888);
+
+                    Canvas canvas = new Canvas(resultBitmap);
+                    canvas.drawBitmap(originalBitmap, 0, 0, null);
+
+                    Paint paint = new Paint();
+                    paint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.SRC_OVER));
+                    canvas.drawBitmap(maskBitmap, 0, 0, paint);
+
+                    // Create an image file name
+                    @SuppressLint("SimpleDateFormat")
+                    String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
+                    String imageFileName = "PNG_" + timeStamp + "_";
+
+                    try {
+                        File image = File.createTempFile(imageFileName, ".png");
+
+                        OutputStream stream = new FileOutputStream(image);
+                        resultBitmap.compress(Bitmap.CompressFormat.PNG, 100, stream);
+                        stream.close();
+
+                        ProcessImageResult result = new ProcessImageResult(
+                            image.getAbsolutePath(),
+                            resultBitmap.getWidth(),
+                            resultBitmap.getHeight()
                         );
 
-                        Bitmap originalBitmap = Bitmap.createScaledBitmap(
-                            Objects.requireNonNull(inputImage.getBitmapInternal()),
-                            maskBitmap.getWidth(),
-                            maskBitmap.getHeight(),
-                            true
-                        );
-
-                        Bitmap resultBitmap = Bitmap.createBitmap(maskBitmap.getWidth(), maskBitmap.getHeight(), Bitmap.Config.ARGB_8888);
-
-                        Canvas canvas = new Canvas(resultBitmap);
-                        canvas.drawBitmap(originalBitmap, 0, 0, null);
-
-                        Paint paint = new Paint();
-                        paint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.SRC_OVER));
-                        canvas.drawBitmap(maskBitmap, 0, 0, paint);
-
-                        // Create an image file name
-                        @SuppressLint("SimpleDateFormat")
-                        String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
-                        String imageFileName = "PNG_" + timeStamp + "_";
-
-                        try {
-                            File image = File.createTempFile(imageFileName, ".png");
-
-                            OutputStream stream = new FileOutputStream(image);
-                            resultBitmap.compress(Bitmap.CompressFormat.PNG, 100, stream);
-                            stream.close();
-
-                            ProcessImageResult result = new ProcessImageResult(
-                                image.getAbsolutePath(),
-                                resultBitmap.getWidth(),
-                                resultBitmap.getHeight()
-                            );
-
-                            callback.success(result);
-                        } catch (Exception exception) {
-                            callback.error(exception);
-                        }
-                    })
-                    .addOnCanceledListener(() -> {
-                        segmenter.close();
-                        callback.cancel();
-                    })
-                    .addOnFailureListener(exception -> {
-                        segmenter.close();
+                        callback.success(result);
+                    } catch (Exception exception) {
                         callback.error(exception);
-                    })
-            );
+                    }
+                })
+                .addOnCanceledListener(() -> {
+                    segmenter.close();
+                    callback.cancel();
+                })
+                .addOnFailureListener(exception -> {
+                    segmenter.close();
+                    callback.error(exception);
+                })
+        );
     }
 
     public void isSubjectSegmentationScannerModuleAvailable(IsGoogleSubjectSegmentationModuleAvailableResultCallback callback) {

--- a/packages/subject-segmentation/package.json
+++ b/packages/subject-segmentation/package.json
@@ -66,15 +66,15 @@
   },
   "devDependencies": {
     "@capacitor/android": "8.0.0",
-    "@capacitor/cli": "8.0.0",
+    "@capacitor/cli": "8.4.2",
     "@capacitor/core": "8.0.0",
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier-plugin-java": "2.6.7",
+    "prettier-plugin-java": "2.9.7",
     "rimraf": "6.1.2",
-    "rollup": "4.53.3",
+    "rollup": "4.62.3",
     "swiftlint": "2.0.0",
     "typescript": "5.9.3"
   },

--- a/packages/text-recognition/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/textrecognition/TextRecognition.java
+++ b/packages/text-recognition/android/src/main/java/io/capawesome/capacitorjs/plugins/mlkit/textrecognition/TextRecognition.java
@@ -33,25 +33,23 @@ public class TextRecognition {
 
         TextRecognizerOptionsInterface recognizerOptions = createRecognizerOptionsForScript(options.getScript());
         final TextRecognizer textRecognizer = com.google.mlkit.vision.text.TextRecognition.getClient(recognizerOptions);
-        plugin
-            .getActivity()
-            .runOnUiThread(() -> {
-                textRecognizer
-                    .process(inputImage)
-                    .addOnSuccessListener(text -> {
-                        textRecognizer.close();
-                        ProcessImageResult result = new ProcessImageResult(text);
-                        callback.success(result);
-                    })
-                    .addOnCanceledListener(() -> {
-                        textRecognizer.close();
-                        callback.error(new Exception(TextRecognitionPlugin.ERROR_PROCESS_IMAGE_CANCELED));
-                    })
-                    .addOnFailureListener(exception -> {
-                        textRecognizer.close();
-                        callback.error(exception);
-                    });
-            });
+        plugin.getActivity().runOnUiThread(() -> {
+            textRecognizer
+                .process(inputImage)
+                .addOnSuccessListener(text -> {
+                    textRecognizer.close();
+                    ProcessImageResult result = new ProcessImageResult(text);
+                    callback.success(result);
+                })
+                .addOnCanceledListener(() -> {
+                    textRecognizer.close();
+                    callback.error(new Exception(TextRecognitionPlugin.ERROR_PROCESS_IMAGE_CANCELED));
+                })
+                .addOnFailureListener(exception -> {
+                    textRecognizer.close();
+                    callback.error(exception);
+                });
+        });
     }
 
     @NonNull

--- a/packages/text-recognition/package.json
+++ b/packages/text-recognition/package.json
@@ -61,15 +61,15 @@
   },
   "devDependencies": {
     "@capacitor/android": "8.0.0",
-    "@capacitor/cli": "8.0.0",
+    "@capacitor/cli": "8.4.2",
     "@capacitor/core": "8.0.0",
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier-plugin-java": "2.6.7",
+    "prettier-plugin-java": "2.9.7",
     "rimraf": "6.1.2",
-    "rollup": "4.53.3",
+    "rollup": "4.62.3",
     "swiftlint": "2.0.0",
     "typescript": "5.9.3"
   },

--- a/packages/translation/package.json
+++ b/packages/translation/package.json
@@ -66,15 +66,15 @@
   },
   "devDependencies": {
     "@capacitor/android": "8.0.0",
-    "@capacitor/cli": "8.0.0",
+    "@capacitor/cli": "8.4.2",
     "@capacitor/core": "8.0.0",
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier-plugin-java": "2.6.7",
+    "prettier-plugin-java": "2.9.7",
     "rimraf": "6.1.2",
-    "rollup": "4.53.3",
+    "rollup": "4.62.3",
     "swiftlint": "2.0.0",
     "typescript": "5.9.3"
   },


### PR DESCRIPTION
Updates four dev dependencies to resolve security advisories reported by `npm audit`. Reduces the audit count from **21 to 5** vulnerabilities (critical `1 → 0`, high `13 → 4`, moderate `7 → 1`).

## Changes

| Package | Scope | Change |
| --- | --- | --- |
| `@capacitor/cli` | all packages | `8.0.0` → `8.4.2` |
| `rollup` | all packages | `4.53.3` → `4.62.3` |
| `prettier-plugin-java` | root + all packages | `2.6.7` → `2.9.7` |
| `turbo` | root | `2.6.3` → `2.10.7` |

All bumps are minor versions — no major versions are touched. `prettier` stays at `3.4.2` and `eslint` at `8.57.0`.

## Resolved advisories

- **`tar`** (critical) — decompression/parse DoS via unlimited input, plus several path traversal and symlink poisoning issues. Reached transitively through `@capacitor/cli`.
- **`lodash` / `lodash-es`** (high) — code injection via `_.template` and prototype pollution in `_.unset` / `_.omit`. Reached transitively through `prettier-plugin-java` via `java-parser` and `chevrotain`; `2.9.0` replaced that parser stack with `web-tree-sitter`.
- **`rollup`** (high) — arbitrary file write via path traversal.
- **`turbo`** (moderate).

## Why `prettier-plugin-java` `2.9.7` and not `2.10.3`

`npm audit` suggests `2.10.3`, but `2.10.0`+ calls `canAttachComment(node, ancestors)` while `prettier` `3.4.2` passes only a single argument. Formatting any Java file then fails with `TypeError: ancestors is not iterable`. The plugin declares `peerDependencies: { "prettier": "^3.0.0" }`, which is too loose to catch this, so npm installs it without complaint.

`2.9.7` is the last release compatible with `prettier` `3.4.2`. It sits outside the vulnerable range (`0.4.0 - 2.6.8 || 2.7.1 - 2.8.1`) and no longer depends on `java-parser`, `chevrotain` or `lodash`, so the security fix is fully preserved.

The `web-tree-sitter` parser rewrite in `2.9.0` changes formatting output, which is why this PR also reformats Java files. Those changes are produced by `prettier --write` and are stylistic only — mostly collapsing method chains that the old parser split across lines.

## Remaining vulnerabilities

The remainder trace back to `brace-expansion` ([GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg)) via the ESLint 8 tree. Only `brace-expansion@5.0.8+` is patched, and version 5 changed its CommonJS export from a bare function to an object, which breaks `minimatch@3` as used by ESLint 8 — so an npm `overrides` entry is not viable. The real blocker is `@ionic/eslint-config`, whose latest release (`0.4.0`) pins `@typescript-eslint/*` v5 and supports ESLint 8 only.

Closing those would mean dropping `@ionic/eslint-config`, moving to `typescript-eslint` v8 and migrating every package to flat config. That is a lint-tooling migration rather than a security fix and belongs in a separate PR. The impact of leaving it is limited to development.

## Notes

- No changeset is included, since these are dev dependencies that do not affect published output.

## Testing

- `prettier --check` passes on every tracked file across all packages.
- Remaining local `turbo run lint` failures are gitignored `example/**/public/assets/*.js` build artifacts and pre-existing SwiftLint findings; neither is present in CI.
- The full Android and iOS build matrix has not been run locally.

## Lockfile note

`npm install --workspaces` updated `@capacitor/cli` and `rollup` but silently left `prettier-plugin-java` at `2.6.7`, keeping 21 stale nested copies recorded in `package-lock.json`. CI would then have installed the old plugin and failed linting. Targeted `-w` installs, `npm dedupe` and a plain reinstall all reported "up to date" without correcting it, so the version strings were updated directly, the orphaned lockfile entries removed, and `npm install` rerun to validate. The tree now resolves to a single hoisted `2.9.7` with no nested copies, which is why the lockfile diff here is larger than in the sibling repositories.
