### PR TITLE
fix(barcode-scanning): stop capture session explicitly in stopScan() on iOS

### DIFF
--- a/.changeset/fix-ios-black-screen-lensfacing.md
+++ b/.changeset/fix-ios-black-screen-lensfacing.md
@@ -1,0 +1,5 @@
+---
+"@capacitor-mlkit/barcode-scanning": patch
+---
+
+fix(ios): stop the capture session when scanning stops, fixing a black screen when switching cameras mid-scan

--- a/packages/barcode-scanning/ios/Plugin/BarcodeScanner.swift
+++ b/packages/barcode-scanning/ios/Plugin/BarcodeScanner.swift
@@ -47,6 +47,10 @@ typealias MLKitBarcodeScanner = MLKitBarcodeScanning.BarcodeScanner
     @objc public func stopScan() {
         DispatchQueue.main.async {
             self.showWebViewBackground()
+            // Stop the capture session before releasing the view - deinit alone can't be trusted
+            // here since the session holds a strong ref back to the view. Otherwise switching
+            // lensFacing quickly can leave the old session running under the new one (#335).
+            self.cameraView?.stopCaptureSession()
             self.cameraView?.removeFromSuperview()
             self.cameraView = nil
         }

--- a/packages/barcode-scanning/ios/Plugin/BarcodeScannerView.swift
+++ b/packages/barcode-scanning/ios/Plugin/BarcodeScannerView.swift
@@ -151,9 +151,21 @@ public protocol BarcodeScannerViewDelegate {
         self.removeTorchButton()
         self.removeCancelButton()
         self.removeVideoPreviewLayer()
+        self.stopCaptureSession()
+        self.barcodeScannerInstance = nil
+    }
+
+    // `setSampleBufferDelegate(self, ...)` gives the capture session a strong reference back to
+    // this view, so `deinit` isn't guaranteed to run when the view is removed - the old session
+    // can keep running underneath a new one. Call this explicitly from `stopScan()` to break that
+    // cycle and actually stop the session. Fixes the black screen from rapidly switching cameras
+    // (issue #335).
+    public func stopCaptureSession() {
+        self.captureSession?.outputs.forEach {
+            ($0 as? AVCaptureVideoDataOutput)?.setSampleBufferDelegate(nil, queue: nil)
+        }
         self.captureSession?.stopRunning()
         self.captureSession = nil
-        self.barcodeScannerInstance = nil
     }
 
     override public func layoutSubviews() {


### PR DESCRIPTION
### Description

On iOS, switching `lensFacing` back and forth while a scan is running can leave you with a black screen and no camera feed.

The root cause: `BarcodeScannerView` sets itself as the `AVCaptureVideoDataOutput`'s sample buffer delegate, and that keeps a strong reference back to the view. So when `stopScan()` removes the view from the superview and drops its own reference, there's no guarantee `deinit` actually runs - the old capture session can just keep going in the background while a new one starts up, and the two end up fighting over the camera.

This adds a `stopCaptureSession()` method on `BarcodeScannerView` that clears the delegate and stops the session, and calls it from `stopScan()` before the view is torn down.

Fixes #335

### Testing

- `npm run lint` and `npm run build` pass across the monorepo.
- `pod install` + `xcodebuild` for the `barcode-scanning` iOS workspace succeeds standalone (compiles against real AVFoundation/MLKit SDKs).
- I don't currently have a physical iOS device available. I tried the Simulator as a fallback, but it's not viable here: this repo's Podfile locks simulator builds to x86_64, which current Apple Silicon Simulator runtimes no longer support, so the app won't even install. Separately, Simulator has no dual front/back cameras, so it couldn't reproduce this specific bug even if it ran.
- The fix has **not been confirmed on a physical device** yet. I'd appreciate it if a maintainer or @lajuffermans (who reported the bug and has a repro environment) could confirm this resolves the black screen before merging. Happy to make any changes needed.

### Checklist

- [ ] The changes have been tested successfully. *(compiled/linted, not yet device-tested - see above)*
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the pull request guidelines.
