### PR TITLE
fix(barcode-scanning): resolve the interface orientation from the view's window scene

### DIFF
--- a/.changeset/barcode-scanning-uiscene-compatibility.md
+++ b/.changeset/barcode-scanning-uiscene-compatibility.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-mlkit/barcode-scanning': patch
+---
+
+fix(ios): resolve the interface orientation from the view's own window scene

--- a/packages/barcode-scanning/ios/Plugin/BarcodeScannerView.swift
+++ b/packages/barcode-scanning/ios/Plugin/BarcodeScannerView.swift
@@ -182,7 +182,7 @@ public protocol BarcodeScannerViewDelegate {
             self.addDetectionAreaView()
         }
 
-        if let interfaceOrientation = UIApplication.shared.windows.first(where: { $0.isKeyWindow })?.windowScene?.interfaceOrientation {
+        if let interfaceOrientation = self.window?.windowScene?.interfaceOrientation {
             let videoOrientation = interfaceOrientationToVideoOrientation(interfaceOrientation)
             self.videoPreviewLayer?.connection?.videoOrientation = videoOrientation
             self.videoOrientation = videoOrientation
@@ -300,8 +300,7 @@ public protocol BarcodeScannerViewDelegate {
     }
 
     private func addCancelButton() {
-        let interfaceOrientation = UIApplication.shared.windows.first(where: { $0.isKeyWindow })?
-            .windowScene?.interfaceOrientation ?? UIInterfaceOrientation.portrait
+        let interfaceOrientation = self.window?.windowScene?.interfaceOrientation ?? UIInterfaceOrientation.portrait
         let image = UIImage(systemName: "xmark")?.withTintColor(.white, renderingMode: .alwaysOriginal)
         let button = UIButton(type: .custom)
         if interfaceOrientation.isPortrait {


### PR DESCRIPTION
## Motivation

The interface orientation was resolved via `UIApplication.shared.windows`, which is deprecated since iOS 15 and unreliable with the scene-based app lifecycle used by the Capacitor 8.5 app template, where it can pick a window of the wrong scene in multi-window apps.

## Changes

- Read the interface orientation from the scanner view's own `window?.windowScene` in `layoutSubviews()` and `addCancelButton()`.
- Keep the existing `.portrait` fallback for the case where the view is not attached to a window yet.