### PR TITLE
docs: mention the new Barcode Scanner plugin as an SPM alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 > [!WARNING]
 > These plugins do **not** support Swift Package Manager (SPM) because the underlying [ML Kit SDKs do not support SPM](https://github.com/googlesamples/mlkit/issues/180#issuecomment-1298964099) (see [#186](https://github.com/capawesome-team/capacitor-mlkit/issues/186)).
+> If you need SPM support for barcode scanning, take a look at our new [Barcode Scanner plugin](https://capawesome.io/docs/sdks/capacitor/barcode-scanner/), which uses AVFoundation and Vision instead of ML Kit on iOS.
 
 <br />
 <div align="center">

--- a/packages/barcode-scanning/README.md
+++ b/packages/barcode-scanning/README.md
@@ -2,6 +2,9 @@
 
 Unofficial Capacitor plugin for [ML Kit Barcode Scanning](https://developers.google.com/ml-kit/vision/barcode-scanning).[^1][^2]
 
+> [!TIP]
+> Looking for Swift Package Manager (SPM) support, a themeable fullscreen scanner UI on both Android and iOS, or an embedded camera view? Take a look at our new [Barcode Scanner plugin](https://capawesome.io/docs/sdks/capacitor/barcode-scanner/) for [Capawesome Insiders](https://capawesome.io/insiders/) — a separate plugin that replaces ML Kit with AVFoundation and Vision on iOS.
+
 <div class="capawesome-z29o10a">
   <a href="https://cloud.capawesome.io/" target="_blank">
     <img alt="Deliver Live Updates to your Capacitor app with Capawesome Cloud" src="https://cloud.capawesome.io/assets/banners/cloud-build-and-deploy-capacitor-apps.png?t=1" />
@@ -74,7 +77,7 @@ npm install @capacitor-mlkit/barcode-scanning
 npx cap sync
 ```
 
-**Attention**: This plugin **only supports CocoaPods** for iOS dependency management. Swift Package Manager (SPM) is not supported for the ML Kit SDK, see [this comment](https://github.com/googlesamples/mlkit/issues/180#issuecomment-1298964099).
+**Attention**: This plugin **only supports CocoaPods** for iOS dependency management. Swift Package Manager (SPM) is not supported for the ML Kit SDK, see [this comment](https://github.com/googlesamples/mlkit/issues/180#issuecomment-1298964099). If you need SPM support, take a look at our new [Barcode Scanner plugin](https://capawesome.io/docs/sdks/capacitor/barcode-scanner/), which uses AVFoundation and Vision instead of ML Kit on iOS.
 
 ### Android
 


### PR DESCRIPTION
Points readers who need Swift Package Manager (SPM) support to the new [Barcode Scanner plugin](https://capawesome.io/docs/sdks/capacitor/barcode-scanner/), which uses AVFoundation and Vision instead of ML Kit on iOS.

Three spots, all extending existing SPM context rather than adding new sections:

- **`README.md`**: appends one sentence to the existing SPM warning at the top.
- **`packages/barcode-scanning/README.md`**: adds a `[!TIP]` callout below the intro, highlighting SPM support, the themeable fullscreen scanner UI on both platforms, and the embedded camera view. Mentions up front that the plugin is available to Capawesome Insiders.
- **`packages/barcode-scanning/README.md`**: appends a pointer to the existing "only supports CocoaPods" note in the installation section.

Only the barcode scanning package is touched — the other packages have no alternative to point to. A `[!TIP]` (not `[!WARNING]`) is used in the package README so it does not read as a deprecation notice.

Ref #186