### PR TITLE
docs: remove demo links from plugins without a demo

### DIFF
--- a/.changeset/swift-horses-cover.md
+++ b/.changeset/swift-horses-cover.md
@@ -1,0 +1,12 @@
+---
+'@capacitor-mlkit/digital-ink-recognition': patch
+'@capacitor-mlkit/entity-extraction': patch
+'@capacitor-mlkit/image-labeling': patch
+'@capacitor-mlkit/language-identification': patch
+'@capacitor-mlkit/object-detection': patch
+'@capacitor-mlkit/pose-detection': patch
+'@capacitor-mlkit/smart-reply': patch
+'@capacitor-mlkit/text-recognition': patch
+---
+
+docs: remove demo links from plugins without a demo

--- a/packages/digital-ink-recognition/README.md
+++ b/packages/digital-ink-recognition/README.md
@@ -71,10 +71,6 @@ platform :ios, '15.5'
 
 No configuration required for this plugin.
 
-## Demo
-
-A working example can be found here: [robingenz/capacitor-mlkit-plugin-demo](https://github.com/robingenz/capacitor-mlkit-plugin-demo)
-
 ## Usage
 
 Before any ink can be recognized, the model for the desired language must be downloaded:

--- a/packages/entity-extraction/README.md
+++ b/packages/entity-extraction/README.md
@@ -74,10 +74,6 @@ platform :ios, '15.5'
 
 No configuration required for this plugin.
 
-## Demo
-
-A working example can be found here: [robingenz/capacitor-mlkit-plugin-demo](https://github.com/robingenz/capacitor-mlkit-plugin-demo)
-
 ## Usage
 
 Before you can extract entities, you must download the model for the language you want to use.

--- a/packages/image-labeling/README.md
+++ b/packages/image-labeling/README.md
@@ -71,10 +71,6 @@ platform :ios, '15.5'
 
 No configuration required for this plugin.
 
-## Demo
-
-A working example can be found here: [robingenz/capacitor-mlkit-plugin-demo](https://github.com/robingenz/capacitor-mlkit-plugin-demo)
-
 ## Usage
 
 The following example shows how to detect labels in an image.

--- a/packages/language-identification/README.md
+++ b/packages/language-identification/README.md
@@ -71,10 +71,6 @@ platform :ios, '15.5'
 
 No configuration required for this plugin.
 
-## Demo
-
-A working example can be found here: [robingenz/capacitor-mlkit-plugin-demo](https://github.com/robingenz/capacitor-mlkit-plugin-demo)
-
 ## Usage
 
 The language identification model ships with the SDK, so no model download is required.

--- a/packages/object-detection/README.md
+++ b/packages/object-detection/README.md
@@ -71,10 +71,6 @@ platform :ios, '15.5'
 
 No configuration required for this plugin.
 
-## Demo
-
-A working example can be found here: [robingenz/capacitor-mlkit-plugin-demo](https://github.com/robingenz/capacitor-mlkit-plugin-demo)
-
 ## Usage
 
 The following example shows how to detect objects in an image.

--- a/packages/pose-detection/README.md
+++ b/packages/pose-detection/README.md
@@ -75,10 +75,6 @@ platform :ios, '15.5'
 
 No configuration required for this plugin.
 
-## Demo
-
-A working example can be found here: [robingenz/capacitor-mlkit-plugin-demo](https://github.com/robingenz/capacitor-mlkit-plugin-demo)
-
 ## Usage
 
 The following example shows how to detect the pose of a person in an image.

--- a/packages/smart-reply/README.md
+++ b/packages/smart-reply/README.md
@@ -71,10 +71,6 @@ platform :ios, '15.5'
 
 No configuration required for this plugin.
 
-## Demo
-
-A working example can be found here: [robingenz/capacitor-mlkit-plugin-demo](https://github.com/robingenz/capacitor-mlkit-plugin-demo)
-
 ## Usage
 
 The following example shows how to generate reply suggestions for a conversation between two users.

--- a/packages/text-recognition/README.md
+++ b/packages/text-recognition/README.md
@@ -79,10 +79,6 @@ platform :ios, '15.5'
 
 No configuration required for this plugin.
 
-## Demo
-
-A working example can be found here: [robingenz/capacitor-mlkit-plugin-demo](https://github.com/robingenz/capacitor-mlkit-plugin-demo)
-
 ## Usage
 
 The following example shows how to recognize text in an image.


### PR DESCRIPTION
The shared demo app (robingenz/capacitor-mlkit-plugin-demo) only covers `barcode-scanning`, `document-scanner`, `face-detection`, `face-mesh-detection`, `selfie-segmentation`, `subject-segmentation` and `translation`. 8 other plugin READMEs pointed readers at it for a demo that does not exist there, so drop the Demo section from those.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The changes have been tested successfully.
- [ ] A changeset has been created (`npm run changeset`).
- [ ] I have read and followed the [pull request guidelines](https://capawesome.io/docs/contributing/pull-requests/).

